### PR TITLE
Deprecate Granite.Widgets.AppMenu

### DIFF
--- a/lib/Widgets/AppMenu.vala
+++ b/lib/Widgets/AppMenu.vala
@@ -26,7 +26,7 @@ namespace Granite.Widgets {
 	/**
 	 * An App Menu is the gear menu that goes on the right of the toolbar.
 	 */
-    [Version (deprecated = true, deprecated_since = "0.4", replacement = "Gtk.MenuButton")]
+    [Version (deprecated = true, deprecated_since = "0.4.1", replacement = "Gtk.MenuButton")]
     public class AppMenu : ToolButtonWithMenu {
 
         /**

--- a/lib/Widgets/AppMenu.vala
+++ b/lib/Widgets/AppMenu.vala
@@ -26,6 +26,7 @@ namespace Granite.Widgets {
 	/**
 	 * An App Menu is the gear menu that goes on the right of the toolbar.
 	 */
+    [Version (deprecated = true, deprecated_since = "0.4", replacement = "Gtk.MenuButton")]
     public class AppMenu : ToolButtonWithMenu {
 
         /**


### PR DESCRIPTION
This is a pretty silly widget. It exists to set two properties.