### PR TITLE
Add new sidebar

### DIFF
--- a/demo/GraniteDemo.vala
+++ b/demo/GraniteDemo.vala
@@ -296,8 +296,8 @@ public class Granite.Demo : Granite.Application {
         test1.children.append (new Granite.Widgets.SidebarRowModel.with_icon_name ("Item 14", "folder-music"));
         test1.children.append (new Granite.Widgets.SidebarRowModel.with_icon_name ("Item 15", "user-trash"));
 
-        const int width = 50;
-        const int height = 50;
+        const int width = 32;
+        const int height = 32;
         var drawbuf = new uint8[width*height*3];
 
         for (int y = 0; y < width; y++) {
@@ -308,6 +308,33 @@ public class Granite.Demo : Granite.Application {
             drawbuf[pixel_index + 1] = (uint8) (128 - (x + y) * 255 / (width * height));
             drawbuf[pixel_index + 2] = (uint8) (x * 255 / width);
           }
+        }
+        
+        for (int y = 0; y < width; y++) {
+          for (int x = 0; x < height; x++) {
+            uint pixel_index = y * width * 3 + x * 3;
+
+            drawbuf[pixel_index] = (uint8) 255;
+            drawbuf[pixel_index + 1] = (uint8) 255;
+            drawbuf[pixel_index + 2] = (uint8) 255;
+          }
+      }
+        
+        for (int y = 0; y < width; y++) {
+            int x=0;
+            uint pixel_index = y * width * 3 + x * 3;
+            
+            drawbuf[pixel_index] = 0;
+            drawbuf[pixel_index + 1] = 0;
+            drawbuf[pixel_index + 2] = 0;
+        }
+        for (int x = 0; x < height; x++) {
+            int y=0;
+            uint pixel_index = y * width * 3 + x * 3;
+            
+            drawbuf[pixel_index] = 0;
+            drawbuf[pixel_index + 1] = 0;
+            drawbuf[pixel_index + 2] = 0;
         }
 
         var pixbuf = new Gdk.Pixbuf.from_data (drawbuf, Gdk.Colorspace.RGB, false, 8, width, height, width * 3);

--- a/demo/GraniteDemo.vala
+++ b/demo/GraniteDemo.vala
@@ -77,6 +77,7 @@ public class Granite.Demo : Granite.Application {
         create_welcome ();
         create_pickers ();
         create_sourcelist ();
+        create_sidebar ();
         create_toast ();
         create_modebutton ();
         create_dynamictab ();
@@ -125,6 +126,7 @@ public class Granite.Demo : Granite.Application {
         var welcome = new Granite.Widgets.Welcome ("Sample Window", "This is a demo of the Granite library.");
         welcome.append ("office-calendar", "TimePicker & DatePicker", "Widgets that allows users to easily pick a time or a date.");
         welcome.append ("tag-new", "SourceList", "A widget that can display a list of items organized in categories.");
+        welcome.append ("tag-new", "Sidebar", "A new widget that can display a list of items organized in categories.");
         welcome.append ("object-inverse", "ModeButton", "This widget is a multiple option modal switch");
         welcome.append ("document-open", "DynamicNotebook", "Tab bar widget designed for a variable number of tabs.");
         welcome.append ("dialog-warning", "AlertView", "A View showing that an action is required to function.");
@@ -142,21 +144,25 @@ public class Granite.Demo : Granite.Application {
                     break;
                 case 2:
                     home_button.show ();
-                    main_stack.set_visible_child_name ("modebutton");
+                    main_stack.set_visible_child_name ("sidebar");
                     break;
                 case 3:
                     home_button.show ();
-                    main_stack.set_visible_child_name ("dynamictab");
+                    main_stack.set_visible_child_name ("modebutton");
                     break;
                 case 4:
                     home_button.show ();
-                    main_stack.set_visible_child_name ("alert");
+                    main_stack.set_visible_child_name ("dynamictab");
                     break;
                 case 5:
                     home_button.show ();
-                    main_stack.set_visible_child_name ("storage");
+                    main_stack.set_visible_child_name ("alert");
                     break;
                 case 6:
+                    home_button.show ();
+                    main_stack.set_visible_child_name ("storage");
+                    break;
+                case 7:
                     home_button.show ();
                     main_stack.set_visible_child_name ("toasts");
                     break;
@@ -187,6 +193,141 @@ public class Granite.Demo : Granite.Application {
         grid.attach (timepicker, 2, 2, 1, 1);
         main_stack.add_named (grid, "pickers");
     }
+
+    private void create_sidebar () {
+        // AZ:  Each item has a number in its name. I used this number to check the
+        //      items end up in the correct place while in development. This function
+        //      also adds items from all over the place, and with all possible
+        //      methods. I wanted to make sure most code paths are checked.
+        //      So the messy code is on purpose :P
+
+        var store = new Granite.Widgets.SidebarStore ();
+
+        var test1 = new Granite.Widgets.SidebarHeaderModel.with_icon_name ("Item 1", "user-home", false);
+        test1.tooltip_text = "This is a header item";
+        test1.indicator_level = 0.3;
+
+        test1.children.append (new Granite.Widgets.SidebarRowModel.with_icon_name ("Item 11", "user-home"));
+        test1.children.append (new Granite.Widgets.SidebarRowModel.with_icon_name ("Item 12", "folder-recent"));
+
+        store.append (test1);
+
+        test1.children.append (new Granite.Widgets.SidebarRowModel.with_icon_name ("Item 13", "folder-documents"));
+        test1.children.append (new Granite.Widgets.SidebarRowModel.with_icon_name ("Item 14", "folder-music"));
+        test1.children.append (new Granite.Widgets.SidebarRowModel.with_icon_name ("Item 15", "user-trash"));
+
+        store.append (new Granite.Widgets.SidebarRowModel.with_icon_name ("Item 2", "user-home"));
+
+        var sidebar = new Granite.Widgets.Sidebar ();
+        sidebar.bind_model (store);
+
+        var test4 = new Granite.Widgets.SidebarExpandableRowModel.with_icon_name ("Item 4", "folder-documents", true);
+        test4.children.append (new Granite.Widgets.SidebarRowModel ("Item 41"));
+        test4.children.append (new Granite.Widgets.SidebarRowModel ("Item 42"));
+
+        store.append (test4);
+
+        test4.action_icon_name = "user-home";
+
+        var test43 = new Granite.Widgets.SidebarExpandableRowModel ("Item 43", false);
+        test4.children.append(test43);
+        var test431 = new Granite.Widgets.SidebarRowModel ("Item 431");
+        test431.badge = 9;
+        test43.children.append(test431);
+
+        store.append (new Granite.Widgets.SidebarRowModel ("Item 5"));
+
+        store.insert (2, new Granite.Widgets.SidebarRowModel ("Item 3"));
+
+        var unexpand_button = new Gtk.Button.with_label ("Unexpand");
+
+        unexpand_button.clicked.connect (() => {
+                test4.expanded = false;
+        });
+
+        var toggle_busy_button = new Gtk.Button.with_label ("Toggle busy");
+
+        toggle_busy_button.clicked.connect (() => {
+            test4.busy = !test4.busy;
+        });
+
+        var toggle_badge_button = new Gtk.Button.with_label ("Toggle badge");
+
+        toggle_badge_button.clicked.connect (() => {
+            if (test4.badge == 0) {
+                test4.badge = 100;
+            } else {
+                test4.badge = 0;
+            }
+        });
+
+        var remove_row_button = new Gtk.Button.with_label ("Remove children rows");
+
+        remove_row_button.clicked.connect (() => {
+            test43.children.remove (test431);
+            test1.children.remove_at (0);
+            test1.children.remove_at (0);
+            test1.children.remove_at (0);
+            test1.children.remove_at (0);
+            test1.children.remove_at (0);
+        });
+
+        var toggle_icon_button = new Gtk.Button.with_label ("Toggle icon");
+
+        toggle_icon_button.clicked.connect (() => {
+            if (test4.icon_name != "folder-documents") {
+                test4.icon_name = "folder-documents";
+            } else {
+                test4.icon_name = "";
+            }
+        });
+
+        var toggle_action_button = new Gtk.Button.with_label ("Toggle action button");
+
+        toggle_action_button.clicked.connect (() => {
+            test4.action_visible = !test4.action_visible;
+        });
+
+        var added = false;
+
+        var add_new_row_button = new Gtk.Button.with_label ("Add new row");
+
+        add_new_row_button.clicked.connect (() => {
+            if (!added) {
+                var new_row = new Granite.Widgets.SidebarRowModel ("Item 44");
+
+                new_row.action_icon_name = "user-home";
+                new_row.icon_name = "user-home";
+                new_row.badge = 20;
+
+                test4.children.append (new_row);
+
+                new_row.show ();
+
+                added = true;
+            }
+        });
+
+        var layout = new Gtk.Grid ();
+        layout.row_spacing = 12;
+        layout.orientation = Gtk.Orientation.VERTICAL;
+        layout.width_request = 650;
+        layout.margin = 24;
+        layout.add (unexpand_button);
+        layout.add (toggle_badge_button);
+        layout.add (toggle_action_button);
+        layout.add (toggle_busy_button);
+        layout.add (toggle_icon_button);
+        layout.add (add_new_row_button);
+        layout.add (remove_row_button);
+
+        var paned = new Gtk.Paned (Gtk.Orientation.HORIZONTAL);
+        paned.add (sidebar);
+        paned.add (layout);
+
+        main_stack.add_named (paned, "sidebar");
+    }
+
 
     private void create_sourcelist () {
         var label = new Gtk.Label ("No selected item");
@@ -241,7 +382,7 @@ public class Granite.Demo : Granite.Application {
         var overlay = new Gtk.Overlay ();
         overlay.add_overlay (grid);
         overlay.add_overlay (toast);
-        
+
         main_stack.add_named (overlay, "toasts");
 
         button.clicked.connect (() => {

--- a/demo/GraniteDemo.vala
+++ b/demo/GraniteDemo.vala
@@ -195,6 +195,89 @@ public class Granite.Demo : Granite.Application {
     }
 
     private void create_sidebar () {
+        var sidebar = new Granite.Widgets.Sidebar ();
+
+        var mode = new Granite.Widgets.ModeButton ();
+        mode.append_text ("Real world");
+        mode.append_text ("Stress");
+        
+        var layout = new Gtk.Grid ();
+        layout.row_spacing = 12;
+        layout.orientation = Gtk.Orientation.VERTICAL;
+        layout.width_request = 650;
+        layout.margin = 24;
+        layout.add (mode);
+        
+        var paned = new Gtk.Paned (Gtk.Orientation.HORIZONTAL);
+        paned.add (sidebar);
+        paned.add (layout);
+
+        main_stack.add_named (paned, "sidebar");
+        
+        mode.mode_changed.connect (() => {
+            foreach (var i in layout.get_children ()) {
+                layout.remove (i);
+            }
+            layout.add (mode);
+            
+            if (mode.selected == 0) {
+                create_sidebar_realworld (layout, sidebar);
+            } else {
+                create_sidebar_stress (layout, sidebar);
+            }
+        });
+        
+    }
+    
+    private void create_sidebar_realworld (Gtk.Grid layout, Granite.Widgets.Sidebar sidebar) {
+        var store = new Granite.Widgets.SidebarStore ();
+        
+        var personal = new Granite.Widgets.SidebarHeaderModel ("Personal", true);
+        store.append (personal);
+
+        personal.children.append (new Granite.Widgets.SidebarRowModel.with_icon_name ("Home", "user-home"));
+        personal.children.append (new Granite.Widgets.SidebarRowModel.with_icon_name ("Recent", "folder-recent"));
+        personal.children.append (new Granite.Widgets.SidebarRowModel.with_icon_name ("Documents", "folder-documents"));
+        personal.children.append (new Granite.Widgets.SidebarRowModel.with_icon_name ("Music", "folder-music"));
+        personal.children.append (new Granite.Widgets.SidebarRowModel.with_icon_name ("Trash", "user-trash"));
+        
+        var devices = new Granite.Widgets.SidebarHeaderModel ("Devices", false);
+        store.append(devices);
+        
+        var file_system = new Granite.Widgets.SidebarRowModel.with_icon_name ("File System", "drive-harddisk");
+        file_system.indicator_level = 0.4;
+        devices.children.append (file_system);
+        
+        var removable_drive = new Granite.Widgets.SidebarRowModel.with_icon_name ("Removable Drive", "drive-removable-media");
+        removable_drive.action_icon_name = "media-eject-symbolic";
+        removable_drive.action_visible = true;
+        removable_drive.indicator_level = 0.8;
+        removable_drive.action_clicked.connect (() => {
+            removable_drive.busy = true;
+            
+            Timeout.add(1000, () => {
+                devices.children.remove (removable_drive); 
+                return false; 
+            });
+        });
+        devices.children.append (removable_drive);
+        
+        var inbox = new Granite.Widgets.SidebarExpandableRowModel.with_icon_name ("Inbox", "mail-inbox", false);
+        inbox.badge = 100;
+        store.append(inbox);
+
+        var gmail = new Granite.Widgets.SidebarRowModel.with_icon_name ("Gmail", "mail-inbox");
+        gmail.badge = 50;
+        inbox.children.append(gmail);
+        
+        var yahoo = new Granite.Widgets.SidebarRowModel.with_icon_name ("Yahoo", "mail-inbox");
+        yahoo.badge = 50;
+        inbox.children.append(yahoo);
+
+        sidebar.bind_model (store);
+    }
+    
+    private void create_sidebar_stress (Gtk.Grid layout, Granite.Widgets.Sidebar sidebar) {
         // AZ:  Each item has a number in its name. I used this number to check the
         //      items end up in the correct place while in development. This function
         //      also adds items from all over the place, and with all possible
@@ -203,12 +286,15 @@ public class Granite.Demo : Granite.Application {
 
         var store = new Granite.Widgets.SidebarStore ();
 
-        var test1 = new Granite.Widgets.SidebarHeaderModel.with_icon_name ("Item 1", "user-home", false);
+        var test1 = new Granite.Widgets.SidebarHeaderModel ("Item 1", false);
         test1.tooltip_text = "This is a header item";
         test1.indicator_level = 0.3;
 
         test1.children.append (new Granite.Widgets.SidebarRowModel.with_icon_name ("Item 11", "user-home"));
         test1.children.append (new Granite.Widgets.SidebarRowModel.with_icon_name ("Item 12", "folder-recent"));
+        test1.children.append (new Granite.Widgets.SidebarRowModel.with_icon_name ("Item 13", "folder-documents"));
+        test1.children.append (new Granite.Widgets.SidebarRowModel.with_icon_name ("Item 14", "folder-music"));
+        test1.children.append (new Granite.Widgets.SidebarRowModel.with_icon_name ("Item 15", "user-trash"));
 
         const int width = 50;
         const int height = 50;
@@ -229,7 +315,7 @@ public class Granite.Demo : Granite.Application {
 
         pixbuf_item.action_icon_pixbuf = pixbuf;
         pixbuf_item.action_visible = true;
-        pixbuf_item.action_icon_name = "folder-documents";
+        pixbuf_item.action_icon_name = "media-eject-symbolic";
 
         test1.children.append (pixbuf_item);
 
@@ -241,7 +327,6 @@ public class Granite.Demo : Granite.Application {
 
         store.append (new Granite.Widgets.SidebarRowModel.with_icon_name ("Item 2", "user-home"));
 
-        var sidebar = new Granite.Widgets.Sidebar ();
         sidebar.bind_model (store);
 
         var test4 = new Granite.Widgets.SidebarExpandableRowModel.with_icon_name ("Item 4", "folder-documents", true);
@@ -250,7 +335,7 @@ public class Granite.Demo : Granite.Application {
 
         store.append (test4);
 
-        test4.action_icon_name = "user-home";
+        test4.action_icon_name = "user-trash-symbolic";
 
         var test43 = new Granite.Widgets.SidebarExpandableRowModel ("Item 43", false);
         test4.children.append(test43);
@@ -331,11 +416,6 @@ public class Granite.Demo : Granite.Application {
             }
         });
 
-        var layout = new Gtk.Grid ();
-        layout.row_spacing = 12;
-        layout.orientation = Gtk.Orientation.VERTICAL;
-        layout.width_request = 650;
-        layout.margin = 24;
         layout.add (unexpand_button);
         layout.add (toggle_badge_button);
         layout.add (toggle_action_button);
@@ -343,12 +423,8 @@ public class Granite.Demo : Granite.Application {
         layout.add (toggle_icon_button);
         layout.add (add_new_row_button);
         layout.add (remove_row_button);
-
-        var paned = new Gtk.Paned (Gtk.Orientation.HORIZONTAL);
-        paned.add (sidebar);
-        paned.add (layout);
-
-        main_stack.add_named (paned, "sidebar");
+        
+        layout.show_all ();
     }
 
 

--- a/demo/GraniteDemo.vala
+++ b/demo/GraniteDemo.vala
@@ -210,6 +210,29 @@ public class Granite.Demo : Granite.Application {
         test1.children.append (new Granite.Widgets.SidebarRowModel.with_icon_name ("Item 11", "user-home"));
         test1.children.append (new Granite.Widgets.SidebarRowModel.with_icon_name ("Item 12", "folder-recent"));
 
+        const int width = 50;
+        const int height = 50;
+        var drawbuf = new uint8[width*height*3];
+
+        for (int y = 0; y < width; y++) {
+          for (int x = 0; x < height; x++) {
+            uint pixel_index = y * width * 3 + x * 3;
+
+            drawbuf[pixel_index] = (uint8) (y * 255 / height);
+            drawbuf[pixel_index + 1] = (uint8) (128 - (x + y) * 255 / (width * height));
+            drawbuf[pixel_index + 2] = (uint8) (x * 255 / width);
+          }
+        }
+
+        var pixbuf = new Gdk.Pixbuf.from_data (drawbuf, Gdk.Colorspace.RGB, false, 8, width, height, width * 3);
+        var pixbuf_item = new Granite.Widgets.SidebarRowModel.with_icon_pixbuf ("Item 12", pixbuf);
+
+        pixbuf_item.action_icon_pixbuf = pixbuf;
+        pixbuf_item.action_visible = true;
+        pixbuf_item.action_icon_name = "folder-documents";
+
+        test1.children.append (pixbuf_item);
+
         store.append (test1);
 
         test1.children.append (new Granite.Widgets.SidebarRowModel.with_icon_name ("Item 13", "folder-documents"));

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -43,6 +43,16 @@ set (VALA_SOURCES
     Widgets/DecoratedWindow.vala
     Widgets/LightWindow.vala
     Widgets/StatusBar.vala
+    Widgets/Sidebar/SidebarParentRowModel.vala
+    Widgets/Sidebar/SidebarHeaderModel.vala
+    Widgets/Sidebar/SidebarExpandableRowModel.vala
+    Widgets/Sidebar/SidebarRowModel.vala
+    Widgets/Sidebar/SidebarHeader.vala
+    Widgets/Sidebar/SidebarExpandableRow.vala
+    Widgets/Sidebar/SidebarRow.vala
+    Widgets/Sidebar/Sidebar.vala
+    Widgets/Sidebar/SidebarStore.vala
+    Widgets/Sidebar/IndicatorBar.vala
     Widgets/SidebarPaned.vala
     Widgets/StorageBar.vala
     Widgets/SourceList.vala

--- a/lib/Widgets/Sidebar/IndicatorBar.vala
+++ b/lib/Widgets/Sidebar/IndicatorBar.vala
@@ -2,6 +2,7 @@
 namespace Granite.Widgets {
     private class IndicatorBar : Gtk.DrawingArea {
         private uint MARGIN = 4;
+        private int HEIGHT = 4;
 
         private double _fill = 0;
         public double fill {
@@ -23,7 +24,7 @@ namespace Granite.Widgets {
         construct {
             hexpand = true;
 
-            set_size_request (-1, 4);
+            set_size_request (-1, HEIGHT);
         }
 
 

--- a/lib/Widgets/Sidebar/IndicatorBar.vala
+++ b/lib/Widgets/Sidebar/IndicatorBar.vala
@@ -1,0 +1,47 @@
+
+namespace Granite.Widgets {
+    private class IndicatorBar : Gtk.DrawingArea {
+        private uint MARGIN = 4;
+
+        private double _fill = 0;
+        public double fill {
+            get {
+                return _fill;
+            }
+
+            set {
+                _fill = value;
+
+                queue_draw ();
+            }
+        }
+
+        public IndicatorBar () {
+            Object ();
+        }
+
+        construct {
+            hexpand = true;
+
+            set_size_request (-1, 4);
+        }
+
+
+        public override bool draw (Cairo.Context context) {
+            var width = get_allocated_width () - 2*MARGIN;
+            var fill_width = fill * width;
+            var height = get_allocated_height ();
+            var x = MARGIN;
+            var y = 0;
+
+            var style_context = get_style_context ();
+            style_context.render_background (context, x, y, width, height);
+            style_context.add_class ("fill");
+            style_context.render_background (context, x, y, fill_width, height);
+            style_context.remove_class ("fill");
+            style_context.render_frame (context,  x, y, width, height);
+
+            return Gdk.EVENT_STOP;
+        }        
+    }
+}

--- a/lib/Widgets/Sidebar/IndicatorBar.vala
+++ b/lib/Widgets/Sidebar/IndicatorBar.vala
@@ -1,3 +1,22 @@
+/*
+* Copyright (c) 2016 elementary LLC (https://launchpad.net/granite)
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public
+* License as published by the Free Software Foundation; either
+* version 2 of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* General Public License for more details.
+*
+* You should have received a copy of the GNU General Public
+* License along with this program; if not, write to the
+* Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+* Boston, MA 02111-1307, USA.
+*
+*/
 
 namespace Granite.Widgets {
     private class IndicatorBar : Gtk.DrawingArea {
@@ -26,7 +45,6 @@ namespace Granite.Widgets {
 
             set_size_request (-1, HEIGHT);
         }
-
 
         public override bool draw (Cairo.Context context) {
             var width = get_allocated_width () - 2*MARGIN;

--- a/lib/Widgets/Sidebar/Sidebar.vala
+++ b/lib/Widgets/Sidebar/Sidebar.vala
@@ -37,6 +37,8 @@ namespace Granite.Widgets {
 
         public void bind_model (ListModel? model) {
             base.bind_model (model, walk_model_items);
+            
+            show_all ();
         }
         
         private Gtk.Widget walk_model_items (Object item) {

--- a/lib/Widgets/Sidebar/Sidebar.vala
+++ b/lib/Widgets/Sidebar/Sidebar.vala
@@ -1,0 +1,43 @@
+
+namespace Granite.Widgets {
+    public class Sidebar : Gtk.ListBox {
+    
+        public Sidebar () {
+            Object ();
+        }
+        
+        construct {
+            build_ui ();
+        }
+
+        private void build_ui () {
+            get_style_context ().add_class (Gtk.STYLE_CLASS_SIDEBAR);
+            width_request = 176;
+            vexpand = true;
+        }
+
+        public void bind_model (ListModel? model) {
+            base.bind_model (model, walk_model_items);
+        }
+        
+        private Gtk.Widget walk_model_items (Object item) {
+            assert (item is SidebarRowModel);    
+
+            if (item is SidebarExpandableRowModel) {
+                var sidebar_model = (SidebarExpandableRowModel) item;
+                
+                return new SidebarExpandableRow (sidebar_model);
+            } else if (item is SidebarHeaderModel) {
+                var sidebar_model = (SidebarHeaderModel) item;
+                
+                return new SidebarHeader (sidebar_model);
+            } else {
+                var sidebar_model = (SidebarRowModel) item;
+
+                return new SidebarRow (sidebar_model);
+            }
+
+
+        }
+    }
+}

--- a/lib/Widgets/Sidebar/Sidebar.vala
+++ b/lib/Widgets/Sidebar/Sidebar.vala
@@ -1,3 +1,22 @@
+/*
+* Copyright (c) 2016 elementary LLC (https://launchpad.net/granite)
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public
+* License as published by the Free Software Foundation; either
+* version 2 of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* General Public License for more details.
+*
+* You should have received a copy of the GNU General Public
+* License along with this program; if not, write to the
+* Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+* Boston, MA 02111-1307, USA.
+*
+*/
 
 namespace Granite.Widgets {
     public class Sidebar : Gtk.ListBox {

--- a/lib/Widgets/Sidebar/SidebarExpandableRow.vala
+++ b/lib/Widgets/Sidebar/SidebarExpandableRow.vala
@@ -1,0 +1,88 @@
+namespace Granite.Widgets {
+    public class SidebarExpandableRow : SidebarRow {
+        public SidebarExpandableRowModel expandable_model { 
+            get {
+                return (SidebarExpandableRowModel) model;
+            }
+        }
+        
+        private Gtk.Button disclosure_button;
+        private Gtk.Revealer disclosure_button_revealer;
+        private Gtk.Grid row_layout;
+        
+        public SidebarExpandableRow (SidebarExpandableRowModel model) {
+            Object (model: (SidebarRowModel) model);
+            
+            build_ui ();
+            connect_signals ();
+            load_data ();
+        }
+
+        
+        private void build_ui () {
+            disclosure_button = new Gtk.Button.from_icon_name ("pan-down-symbolic", Gtk.IconSize.BUTTON);
+            disclosure_button.get_style_context ().remove_class (Gtk.STYLE_CLASS_BUTTON);
+            
+            disclosure_button_revealer = new Gtk.Revealer ();
+            disclosure_button_revealer.transition_type = Gtk.RevealerTransitionType.CROSSFADE;
+            disclosure_button_revealer.add (disclosure_button);
+
+            row_layout = build_grid ();
+            row_layout.insert_column (0);
+            row_layout.attach (disclosure_button_revealer, 0, 0, 1, 2);
+
+            add (row_layout);
+        }
+
+        protected void connect_signals () {
+            base.connect_signals ();
+
+            expandable_model.children.items_changed.connect (handle_children_items_changed);
+
+            expandable_model.expanded_changed.connect (update_disclosure_button_icon);
+            disclosure_button.clicked.connect (toggle_reveal_children);
+            
+            disclosure_button_revealer.notify["child-revealed"].connect (handle_disclosure_button_revealer_state_changed);
+
+            expandable_model.show.connect (() => { show (); });
+            expandable_model.hide.connect (() => { hide (); });
+        }
+
+        private void load_data () {
+            base.load_data ();
+
+            update_disclosure_button_icon (expandable_model.expanded);
+            
+            handle_children_items_changed ();
+        }
+        
+        private void handle_disclosure_button_revealer_state_changed () {
+            if (!disclosure_button_revealer.reveal_child) {
+                disclosure_button_revealer.visible = false;
+            }
+        }
+
+        private void handle_children_items_changed () {
+            if (expandable_model.children.get_n_items () == 0) {
+                disclosure_button_revealer.no_show_all = true;
+                disclosure_button_revealer.reveal_child = false;
+            } else {
+                disclosure_button_revealer.no_show_all = false;
+                disclosure_button_revealer.show_all ();
+                disclosure_button_revealer.reveal_child = true;
+            }
+        }
+
+        private void update_disclosure_button_icon (bool expanded) {
+            if (expanded) {
+                ((Gtk.Image) disclosure_button.image).icon_name = "pan-down-symbolic";
+            } else {
+                ((Gtk.Image) disclosure_button.image).icon_name = "pan-end-symbolic";
+            }
+        }
+
+        private void toggle_reveal_children () {
+            expandable_model.expanded = !expandable_model.expanded;
+        }
+    }
+}

--- a/lib/Widgets/Sidebar/SidebarExpandableRow.vala
+++ b/lib/Widgets/Sidebar/SidebarExpandableRow.vala
@@ -1,3 +1,23 @@
+/*
+* Copyright (c) 2016 elementary LLC (https://launchpad.net/granite)
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public
+* License as published by the Free Software Foundation; either
+* version 2 of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* General Public License for more details.
+*
+* You should have received a copy of the GNU General Public
+* License along with this program; if not, write to the
+* Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+* Boston, MA 02111-1307, USA.
+*
+*/
+
 namespace Granite.Widgets {
     public class SidebarExpandableRow : SidebarRow {
         public SidebarExpandableRowModel expandable_model {

--- a/lib/Widgets/Sidebar/SidebarExpandableRow.vala
+++ b/lib/Widgets/Sidebar/SidebarExpandableRow.vala
@@ -1,28 +1,27 @@
 namespace Granite.Widgets {
     public class SidebarExpandableRow : SidebarRow {
-        public SidebarExpandableRowModel expandable_model { 
+        public SidebarExpandableRowModel expandable_model {
             get {
                 return (SidebarExpandableRowModel) model;
             }
         }
-        
+
         private Gtk.Button disclosure_button;
         private Gtk.Revealer disclosure_button_revealer;
         private Gtk.Grid row_layout;
-        
+
         public SidebarExpandableRow (SidebarExpandableRowModel model) {
             Object (model: (SidebarRowModel) model);
-            
+
             build_ui ();
             connect_signals ();
             load_data ();
         }
 
-        
         private void build_ui () {
             disclosure_button = new Gtk.Button.from_icon_name ("pan-down-symbolic", Gtk.IconSize.BUTTON);
             disclosure_button.get_style_context ().remove_class (Gtk.STYLE_CLASS_BUTTON);
-            
+
             disclosure_button_revealer = new Gtk.Revealer ();
             disclosure_button_revealer.transition_type = Gtk.RevealerTransitionType.CROSSFADE;
             disclosure_button_revealer.add (disclosure_button);
@@ -41,7 +40,7 @@ namespace Granite.Widgets {
 
             expandable_model.expanded_changed.connect (update_disclosure_button_icon);
             disclosure_button.clicked.connect (toggle_reveal_children);
-            
+
             disclosure_button_revealer.notify["child-revealed"].connect (handle_disclosure_button_revealer_state_changed);
 
             expandable_model.show.connect (() => { show (); });
@@ -52,10 +51,10 @@ namespace Granite.Widgets {
             base.load_data ();
 
             update_disclosure_button_icon (expandable_model.expanded);
-            
+
             handle_children_items_changed ();
         }
-        
+
         private void handle_disclosure_button_revealer_state_changed () {
             if (!disclosure_button_revealer.reveal_child) {
                 disclosure_button_revealer.visible = false;

--- a/lib/Widgets/Sidebar/SidebarExpandableRowModel.vala
+++ b/lib/Widgets/Sidebar/SidebarExpandableRowModel.vala
@@ -19,13 +19,17 @@
 */
 
 namespace Granite.Widgets {
-    public class SidebarExpandableRowModel : SidebarParentRowModel {        
+    public class SidebarExpandableRowModel : SidebarParentRowModel {
         public SidebarExpandableRowModel (string label, bool expanded) {
             Object (label: label, expanded: expanded);
         }
 
         public SidebarExpandableRowModel.with_icon_name (string label, string icon_name, bool expanded) {
             Object (label: label, icon_name: icon_name, expanded: expanded);
+        }
+
+        public SidebarExpandableRowModel.with_icon_pixbuf (string label, Gdk.Pixbuf icon_pixbuf, bool expanded) {
+            Object (label: label, icon_pixbuf: icon_pixbuf, expanded: expanded);
         }
 
     }

--- a/lib/Widgets/Sidebar/SidebarExpandableRowModel.vala
+++ b/lib/Widgets/Sidebar/SidebarExpandableRowModel.vala
@@ -1,0 +1,32 @@
+/*
+* Copyright (c) 2016 elementary LLC (https://launchpad.net/granite)
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public
+* License as published by the Free Software Foundation; either
+* version 2 of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* General Public License for more details.
+*
+* You should have received a copy of the GNU General Public
+* License along with this program; if not, write to the
+* Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+* Boston, MA 02111-1307, USA.
+*
+*/
+
+namespace Granite.Widgets {
+    public class SidebarExpandableRowModel : SidebarParentRowModel {        
+        public SidebarExpandableRowModel (string label, bool expanded) {
+            Object (label: label, expanded: expanded);
+        }
+
+        public SidebarExpandableRowModel.with_icon_name (string label, string icon_name, bool expanded) {
+            Object (label: label, icon_name: icon_name, expanded: expanded);
+        }
+
+    }
+}

--- a/lib/Widgets/Sidebar/SidebarHeader.vala
+++ b/lib/Widgets/Sidebar/SidebarHeader.vala
@@ -1,0 +1,96 @@
+namespace Granite.Widgets {
+    public class SidebarHeader : SidebarRow {
+        public SidebarHeaderModel header_model {
+            get {
+                return (SidebarHeaderModel) model;
+            }
+        }
+
+        private Gtk.Revealer disclosure_image_revealer;
+        private Gtk.Image disclosure_image;
+        private Gtk.Grid row_layout;
+        private Gtk.Button row_box;
+
+        public SidebarHeader (SidebarHeaderModel model) {
+            Object (model: (SidebarRowModel) model);
+            
+            build_ui ();
+            connect_signals ();
+            load_data ();
+        }
+
+
+        private void build_ui () {
+            selectable = false;
+
+            disclosure_image = new Gtk.Image.from_icon_name ("pan-down-symbolic", Gtk.IconSize.BUTTON);
+
+            disclosure_image_revealer = new Gtk.Revealer ();
+            disclosure_image_revealer.transition_type = Gtk.RevealerTransitionType.CROSSFADE;
+            disclosure_image_revealer.add (disclosure_image);
+
+            row_layout = build_grid ();
+            row_layout.attach (disclosure_image_revealer, 3, 0, 1, 2);
+            set_bold ();
+
+            row_box = new Gtk.Button ();
+            row_box.get_style_context ().remove_class (Gtk.STYLE_CLASS_BUTTON);
+
+            row_box.add (row_layout);
+
+            add (row_box);
+        }
+
+        protected void connect_signals () {
+            base.connect_signals ();
+            
+            header_model.children.items_changed.connect (handle_children_items_changed);
+
+            header_model.expanded_changed.connect (update_disclosure_image);
+            row_box.clicked.connect (toggle_reveal_children);
+
+            row_box.enter_notify_event.connect (() => {
+                disclosure_image_revealer.reveal_child = true;
+                return false;
+            });
+
+            row_box.leave_notify_event.connect (() => {
+                disclosure_image_revealer.reveal_child = false;
+                return false;
+            });
+
+            header_model.show.connect (() => { show (); });
+            header_model.hide.connect (() => { hide (); });
+        }
+
+        private void load_data () {
+            base.load_data ();
+
+            update_disclosure_image (header_model.expanded);
+            
+            handle_children_items_changed ();
+        }
+
+        private void handle_children_items_changed () {
+            if (header_model.children.get_n_items () == 0) {
+                no_show_all = true;
+                hide ();
+            } else {
+                no_show_all = false;
+                show_all ();
+            }
+        }
+
+        private void update_disclosure_image (bool expanded) {
+            if (expanded) {
+                disclosure_image.icon_name = "pan-down-symbolic";
+            } else {
+                disclosure_image.icon_name = "pan-end-symbolic";
+            }
+        }
+
+        private void toggle_reveal_children () {
+            header_model.expanded = !header_model.expanded;
+        }
+    }
+}

--- a/lib/Widgets/Sidebar/SidebarHeader.vala
+++ b/lib/Widgets/Sidebar/SidebarHeader.vala
@@ -1,3 +1,23 @@
+/*
+* Copyright (c) 2016 elementary LLC (https://launchpad.net/granite)
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public
+* License as published by the Free Software Foundation; either
+* version 2 of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* General Public License for more details.
+*
+* You should have received a copy of the GNU General Public
+* License along with this program; if not, write to the
+* Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+* Boston, MA 02111-1307, USA.
+*
+*/
+
 namespace Granite.Widgets {
     public class SidebarHeader : SidebarRow {
         public SidebarHeaderModel header_model {

--- a/lib/Widgets/Sidebar/SidebarHeader.vala
+++ b/lib/Widgets/Sidebar/SidebarHeader.vala
@@ -50,7 +50,7 @@ namespace Granite.Widgets {
             disclosure_image_revealer.add (disclosure_image);
 
             row_layout = build_grid ();
-            row_layout.attach (disclosure_image_revealer, 3, 0, 1, 2);
+            row_layout.attach (disclosure_image_revealer, 4, 0, 1, 2);
             set_bold ();
 
             row_box = new Gtk.Button ();

--- a/lib/Widgets/Sidebar/SidebarHeaderModel.vala
+++ b/lib/Widgets/Sidebar/SidebarHeaderModel.vala
@@ -23,10 +23,5 @@ namespace Granite.Widgets {
         public SidebarHeaderModel (string label, bool expanded) {
             Object (label: label, expanded: expanded);
         }
-
-        public SidebarHeaderModel.with_icon_name (string label, string icon_name, bool expanded) {
-            Object (label: label, icon_name: icon_name, expanded: expanded);
-        }
-
     }
 }

--- a/lib/Widgets/Sidebar/SidebarHeaderModel.vala
+++ b/lib/Widgets/Sidebar/SidebarHeaderModel.vala
@@ -1,0 +1,32 @@
+/*
+* Copyright (c) 2016 elementary LLC (https://launchpad.net/granite)
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public
+* License as published by the Free Software Foundation; either
+* version 2 of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* General Public License for more details.
+*
+* You should have received a copy of the GNU General Public
+* License along with this program; if not, write to the
+* Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+* Boston, MA 02111-1307, USA.
+*
+*/
+
+namespace Granite.Widgets {
+    public class SidebarHeaderModel : SidebarParentRowModel {
+        public SidebarHeaderModel (string label, bool expanded) {
+            Object (label: label, expanded: expanded);
+        }
+
+        public SidebarHeaderModel.with_icon_name (string label, string icon_name, bool expanded) {
+            Object (label: label, icon_name: icon_name, expanded: expanded);
+        }
+
+    }
+}

--- a/lib/Widgets/Sidebar/SidebarParentRowModel.vala
+++ b/lib/Widgets/Sidebar/SidebarParentRowModel.vala
@@ -1,0 +1,105 @@
+/*
+* Copyright (c) 2016 elementary LLC (https://launchpad.net/granite)
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public
+* License as published by the Free Software Foundation; either
+* version 2 of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* General Public License for more details.
+*
+* You should have received a copy of the GNU General Public
+* License along with this program; if not, write to the
+* Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+* Boston, MA 02111-1307, USA.
+*
+*/
+
+namespace Granite.Widgets {
+    public abstract class SidebarParentRowModel : SidebarRowModel {
+        
+        public signal void items_changed (uint position, uint removed, uint added);
+        public signal void expanded_changed (bool expanded);
+
+        public Granite.Widgets.SidebarStore children { 
+            get; 
+            private set; 
+            default = new Granite.Widgets.SidebarStore ();
+        }
+
+        private bool _expanded;
+        public bool expanded {
+            get {
+                return _expanded;
+            }
+            set {
+                _expanded = value;
+                expanded_changed (_expanded);
+
+                foreach (var item in children.root_items) {
+                    if (value) {
+                        item.show ();
+                    } else {
+                        item.hide ();
+                    }
+                }
+            }
+        }
+
+        public SidebarParentRowModel (string label, bool expanded) {
+            Object (label: label, expanded: expanded);
+        }
+
+        public SidebarParentRowModel.with_icon_name (string label, string icon_name, bool expanded) {
+            Object (label: label, icon_name: icon_name, expanded: expanded);
+        }
+
+        construct {
+            connect_signals ();
+        }
+
+        private void connect_signals () {
+            children.items_changed.connect ((position, removed, added) => {
+                items_changed (position, removed, added);
+            });
+
+            children.item_added.connect (handle_item_added);
+            
+            level_changed.connect (handle_level_changed);
+            
+            hide.connect (handle_hide_propagation);
+            show.connect (handle_show_propagation);
+        }
+        
+        private void handle_item_added (SidebarRowModel item) {
+            if (expanded) {
+                item.show ();
+            } else {
+                item.hide ();
+            }
+        }
+
+        private void handle_level_changed (uint level) {
+            children.level = level;
+        }
+
+        private void handle_show_propagation () {
+            if (expanded) {                
+                foreach (var item in children.root_items) {
+                    item.show ();
+                }
+            }
+        }
+        
+        private void handle_hide_propagation () {
+            if (expanded) {
+                foreach (var item in children.root_items) {
+                    item.hide ();
+                }
+            }
+        }
+    }
+}

--- a/lib/Widgets/Sidebar/SidebarRow.vala
+++ b/lib/Widgets/Sidebar/SidebarRow.vala
@@ -1,3 +1,22 @@
+/*
+* Copyright (c) 2016 elementary LLC (https://launchpad.net/granite)
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public
+* License as published by the Free Software Foundation; either
+* version 2 of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* General Public License for more details.
+*
+* You should have received a copy of the GNU General Public
+* License along with this program; if not, write to the
+* Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+* Boston, MA 02111-1307, USA.
+*
+*/
 
 namespace Granite.Widgets {
     public class SidebarRow : Gtk.ListBoxRow {

--- a/lib/Widgets/Sidebar/SidebarRow.vala
+++ b/lib/Widgets/Sidebar/SidebarRow.vala
@@ -75,6 +75,7 @@ namespace Granite.Widgets {
             button_revealer.add (button_stack);
 
             indicator_bar = new IndicatorBar ();
+            indicator_bar.margin_bottom = 2;
 
             var layout = new Gtk.Grid ();
             layout.margin_start = (int) model.level * 6;
@@ -134,9 +135,11 @@ namespace Granite.Widgets {
 
         private void handle_indicator_level_changed (double indicator_level) {
             if (indicator_level < 0) {
+                get_style_context ().remove_class ("indicator-present");
                 indicator_bar.no_show_all = true;
                 indicator_bar.hide ();
             } else {
+                get_style_context ().add_class ("indicator-present");
                 indicator_bar.no_show_all = false;
                 indicator_bar.fill = indicator_level;
                 indicator_bar.show_all ();

--- a/lib/Widgets/Sidebar/SidebarRow.vala
+++ b/lib/Widgets/Sidebar/SidebarRow.vala
@@ -231,7 +231,6 @@ namespace Granite.Widgets {
                 return;
             }
 
-            action_image.pixbuf = null;
             action_image.icon_name = action_icon_name;
         }
 
@@ -239,7 +238,7 @@ namespace Granite.Widgets {
             if (action_icon_pixbuf == null) {
                 return;
             }
-            action_image.icon_name = null;
+            
             action_image.pixbuf = action_icon_pixbuf.scale_simple(PIXBUF_ICON_WIDTH, PIXBUF_ICON_HEIGHT, Gdk.InterpType.BILINEAR);
         }
 

--- a/lib/Widgets/Sidebar/SidebarRow.vala
+++ b/lib/Widgets/Sidebar/SidebarRow.vala
@@ -67,7 +67,6 @@ namespace Granite.Widgets {
 
             badge_label = new Gtk.Label ("");
             badge_label.get_style_context ().add_class ("badge");
-            badge_label.margin_end = 3;
             badge_label.valign = Gtk.Align.CENTER;
 
             badge_revealer = new Gtk.Revealer ();
@@ -86,6 +85,7 @@ namespace Granite.Widgets {
 
             button_stack = new Gtk.Stack ();
             button_stack.transition_type = Gtk.StackTransitionType.CROSSFADE;
+            button_stack.margin_start = 3;
             button_stack.add (action_button);
             button_stack.add (spinner);
 
@@ -101,8 +101,8 @@ namespace Granite.Widgets {
             layout.attach (icon_revealer, 0, 0, 1, 2);
             layout.attach (row_label, 1, 0, 1, 1);
             layout.attach (indicator_bar, 1, 1, 1, 1);
-            layout.attach (button_revealer, 2, 0, 1, 2);
-            layout.attach (badge_revealer, 3, 0, 1, 2);
+            layout.attach (button_revealer, 3, 0, 1, 2);
+            layout.attach (badge_revealer, 2, 0, 1, 2);
 
             return layout;
         }
@@ -138,7 +138,6 @@ namespace Granite.Widgets {
                     no_show_all = true;
                 }
             });
-
         }
 
         protected void load_data () {

--- a/lib/Widgets/Sidebar/SidebarRow.vala
+++ b/lib/Widgets/Sidebar/SidebarRow.vala
@@ -1,0 +1,255 @@
+
+namespace Granite.Widgets {
+    public class SidebarRow : Gtk.ListBoxRow {
+        public SidebarRowModel model { get; construct; }
+        
+        private Gtk.Button action_button;
+        private Gtk.Image action_image;
+        private Gtk.Image icon;
+        private Gtk.Revealer icon_revealer;
+        private Gtk.Label badge_label;
+        private Gtk.Label row_label;
+        private Gtk.Revealer badge_revealer;
+        private Gtk.Revealer button_revealer;
+        private Gtk.Revealer revealer;
+        private Gtk.Spinner spinner;
+        private IndicatorBar indicator_bar;
+        private Gtk.Stack button_stack;
+
+        public SidebarRow (SidebarRowModel model) {
+            Object (model: model);
+            
+            build_ui ();
+            connect_signals ();
+            load_data ();
+        }
+
+        private void build_ui () {
+            add (build_grid ());
+        }
+
+        protected Gtk.Grid build_grid () {
+            icon = new Gtk.Image ();
+            icon.get_style_context ().add_class ("icon");
+            
+            icon_revealer = new Gtk.Revealer ();
+            icon_revealer.transition_type = Gtk.RevealerTransitionType.CROSSFADE;
+            icon_revealer.add (icon);
+
+            row_label = new Gtk.Label ("");
+            row_label.ellipsize = Pango.EllipsizeMode.END;
+            row_label.xalign = 0;
+            row_label.hexpand = true;
+            row_label.get_style_context ().add_class ("row-label");
+
+            badge_label = new Gtk.Label ("");
+            badge_label.get_style_context ().add_class ("badge");
+            badge_label.margin_end = 3;
+            badge_label.valign = Gtk.Align.CENTER;
+
+            badge_revealer = new Gtk.Revealer ();
+            badge_revealer.transition_type = Gtk.RevealerTransitionType.CROSSFADE;
+            badge_revealer.add (badge_label);
+
+            action_image = new Gtk.Image ();
+            action_image.icon_size = Gtk.IconSize.BUTTON;
+            
+            action_button = new Gtk.Button ();
+            action_button.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
+            action_button.image = action_image;
+
+            spinner = new Gtk.Spinner ();
+
+            button_stack = new Gtk.Stack ();
+            button_stack.transition_type = Gtk.StackTransitionType.CROSSFADE;
+            button_stack.add (action_button);
+            button_stack.add (spinner);
+
+            button_revealer = new Gtk.Revealer ();
+            button_revealer.transition_type = Gtk.RevealerTransitionType.CROSSFADE;
+            button_revealer.add (button_stack);
+
+            indicator_bar = new IndicatorBar ();
+
+            var layout = new Gtk.Grid ();
+            layout.margin_start = (int) model.level * 6;
+            layout.attach (icon_revealer, 0, 0, 1, 2);
+            layout.attach (row_label, 1, 0, 1, 1);
+            layout.attach (indicator_bar, 1, 1, 1, 1);
+            layout.attach (button_revealer, 2, 0, 1, 2);
+            layout.attach (badge_revealer, 3, 0, 1, 2);
+
+            return layout;
+        }
+
+        protected void connect_signals () {
+            action_button.clicked.connect (() => {
+                model.action_clicked ();
+            });
+            
+            model.badge_changed.connect (handle_badge_changed);
+            model.icon_name_changed.connect (handle_icon_name_changed);
+            model.label_changed.connect (handle_label_changed);
+            model.tooltip_text_changed.connect (handle_tooltip_text_changed);
+            model.busy_changed.connect (handle_busy_changed);
+            model.action_icon_name_changed.connect (handle_action_icon_name_changed);
+            model.action_visible_changed.connect (handle_action_visible_changed);
+            model.indicator_level_changed.connect (handle_indicator_level_changed);
+            model.show.connect (() => { show (); });
+            model.hide.connect (() => { hide (); });
+
+            badge_revealer.notify["child-revealed"].connect (handle_badge_revealer_state_changed);
+            button_revealer.notify["child-revealed"].connect (handle_button_revealer_state_changed);
+            icon_revealer.notify["child-revealed"].connect (handle_icon_revealer_state_changed);
+
+            realize.connect (() => {
+                if (model.visible) {
+                    show_all ();
+                } else {
+                    hide ();
+                }
+            });
+            
+        }
+
+        protected void load_data () {
+            handle_badge_changed (model.badge);
+            handle_label_changed (model.label);
+            handle_tooltip_text_changed (model.tooltip_text);
+            handle_icon_name_changed (model.icon_name);
+            handle_action_icon_name_changed (model.action_icon_name);
+            handle_action_visible_changed (model.action_visible);
+            handle_busy_changed (model.busy);
+            handle_indicator_level_changed (model.indicator_level);
+        }
+
+        private void handle_indicator_level_changed (double indicator_level) {
+            if (indicator_level < 0) {
+                indicator_bar.no_show_all = true;
+                indicator_bar.hide ();
+            } else {
+                indicator_bar.no_show_all = false;
+                indicator_bar.fill = indicator_level;
+                indicator_bar.show_all ();
+            }
+        }
+
+        private void handle_badge_revealer_state_changed () {
+            if (!badge_revealer.reveal_child) {
+                badge_revealer.visible = false;
+            }
+        }
+
+        private void handle_icon_revealer_state_changed () {
+            if (!icon_revealer.reveal_child) {
+                icon_revealer.visible = false;
+            }
+        }
+        
+        private void handle_button_revealer_state_changed () {
+            if (!button_revealer.reveal_child) {
+                button_revealer.visible = false;
+                
+                if (!model.busy) {
+                    spinner.active = false;
+                }
+            }
+        }
+
+        private void handle_badge_changed (uint badge) {
+            if (badge != 0) {
+                if (badge > 999) {
+                    badge_label.label = "∞";
+                } else {
+                    badge_label.label = badge.to_string ();
+                }
+
+                badge_revealer.no_show_all = false;
+                badge_revealer.show_all ();
+                badge_revealer.reveal_child = true;
+            } else {
+                badge_revealer.no_show_all = true;
+                badge_revealer.reveal_child = false;
+            }
+        }
+        
+        private void handle_label_changed (string label) {
+            row_label.set_text (label);
+        }
+
+        private void handle_tooltip_text_changed (string? tooltip_text) {
+            if (tooltip_text == null) {
+                return;
+            }
+
+            this.tooltip_text = tooltip_text;
+        }
+        
+        private void handle_icon_name_changed (string? icon_name) {
+            if (icon_name == null || icon_name == "") {
+                icon_revealer.reveal_child = false;
+                icon_revealer.no_show_all = true;
+            } else {
+                icon.icon_name = icon_name;
+                icon_revealer.no_show_all = false;
+                icon_revealer.show_all ();
+                icon_revealer.reveal_child = true;
+            }
+        }
+
+        private void handle_action_icon_name_changed (string? action_icon_name) {
+            if (action_icon_name == null) {
+                return;
+            }
+
+            action_image.icon_name = action_icon_name;
+        }
+        
+        private void handle_action_visible_changed (bool action_visible) {            
+            if (action_visible) {
+                show_button_revealer (action_button);
+            } else {
+                hide_button_revealer ();
+            }
+        }
+
+        private void handle_busy_changed (bool busy) {
+            if (busy) {
+                spinner.active = true;
+                show_button_revealer (spinner);
+            } else {
+                hide_button_revealer ();
+            }
+        }
+
+        private void show_button_revealer (Gtk.Widget item) {
+            button_revealer.no_show_all = false;
+            button_revealer.show_all ();
+            switch_button_stack_to (item);
+            button_revealer.reveal_child = true;
+        }
+
+        private void hide_button_revealer () {
+            if (model.busy) {
+                switch_button_stack_to (spinner);
+            } else if (model.action_visible) {
+                switch_button_stack_to (action_button);
+            } else {
+                button_revealer.no_show_all = true;
+                button_revealer.reveal_child = false;
+            }
+        }
+        
+        private void switch_button_stack_to (Gtk.Widget item) {
+            if (model.busy) {
+                button_stack.visible_child = spinner;
+            } else {
+                button_stack.visible_child = item;
+            }
+        }
+        
+        public void set_bold () {
+            row_label.get_style_context ().add_class ("h4");
+        }
+    }
+}

--- a/lib/Widgets/Sidebar/SidebarRow.vala
+++ b/lib/Widgets/Sidebar/SidebarRow.vala
@@ -122,8 +122,8 @@ namespace Granite.Widgets {
             model.action_icon_pixbuf_changed.connect (handle_action_icon_pixbuf_changed);
             model.action_visible_changed.connect (handle_action_visible_changed);
             model.indicator_level_changed.connect (handle_indicator_level_changed);
-            model.show.connect (() => { show (); });
-            model.hide.connect (() => { hide (); });
+            model.show.connect (() => { no_show_all = false; show_all (); });
+            model.hide.connect (() => { no_show_all = true; hide (); });
 
             badge_revealer.notify["child-revealed"].connect (handle_badge_revealer_state_changed);
             button_revealer.notify["child-revealed"].connect (handle_button_revealer_state_changed);
@@ -132,8 +132,10 @@ namespace Granite.Widgets {
             realize.connect (() => {
                 if (model.visible) {
                     show_all ();
+                    no_show_all = false;
                 } else {
                     hide ();
+                    no_show_all = true;
                 }
             });
 

--- a/lib/Widgets/Sidebar/SidebarRowModel.vala
+++ b/lib/Widgets/Sidebar/SidebarRowModel.vala
@@ -1,0 +1,198 @@
+/*
+* Copyright (c) 2016 elementary LLC (https://launchpad.net/granite)
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public
+* License as published by the Free Software Foundation; either
+* version 2 of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* General Public License for more details.
+*
+* You should have received a copy of the GNU General Public
+* License along with this program; if not, write to the
+* Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+* Boston, MA 02111-1307, USA.
+*
+*/
+
+namespace Granite.Widgets {
+    public class SidebarRowModel : GLib.Object {
+        public SidebarStore parent_store { get; private set; }
+        
+        public bool visible { get; private set; default = true; }
+        
+        // AZ:  I'm not sure how to prevent these from being called from the
+        //      outside. It will be overrided as soon as an expand/contract
+        //      happens on a parent row.
+        public signal void hide ();
+        public signal void show ();
+
+        public signal void action_clicked ();
+
+        private uint _level;
+        public uint level {
+            get {
+                return _level;
+            }
+            set {
+                _level = value;
+                
+                level_changed (value);
+            }
+        }
+        public signal void level_changed (uint level);
+        
+        private double _indicator_level = -1;
+        public double indicator_level {
+            get {
+                return _indicator_level;
+            }
+            set {
+                _indicator_level = value;
+
+                indicator_level_changed (value);
+            }
+        }
+        public signal void indicator_level_changed (double indicator_level);
+
+        private bool _busy;
+        public bool busy {
+            get {
+                return _busy;
+            }
+            set {
+                _busy = value;
+                
+                busy_changed (value);
+            }
+        }
+        public signal void busy_changed (bool busy);
+
+        
+        private string _label;
+        public string label {
+            get {
+                return _label;
+            }
+            construct set {
+                _label = value;
+                
+                label_changed (value);
+            }
+        }
+        public signal void label_changed (string label);
+        
+        private string _tooltip_text;
+        public string tooltip_text {
+            get {
+                return _tooltip_text;
+            }
+            construct set {
+                _tooltip_text = value;
+                
+                tooltip_text_changed (value);
+            }
+        }
+        public signal void tooltip_text_changed (string tooltip_text);
+        
+        private string _icon_name = "";
+        public string icon_name {
+            get {
+                return _icon_name;
+            }
+            set {
+                _icon_name = value;
+                
+                icon_name_changed (value);
+            }
+        }
+        public signal void icon_name_changed (string icon_name);
+        
+        private string _action_icon_name = "";
+        public string action_icon_name {
+            get {
+                return _action_icon_name;
+            }
+            set {
+                _action_icon_name = value;
+
+                action_icon_name_changed (value);
+            }
+        }
+        public signal void action_icon_name_changed (string label);
+        
+        private bool _action_visible;
+        public bool action_visible {
+            get {
+                return _action_visible;
+            }
+            set {
+                _action_visible = value;
+
+                action_visible_changed (value);
+            }
+        }
+        public signal void action_visible_changed (bool level);
+
+        private uint _badge;
+        public uint badge {
+            get {
+                return _badge;
+            }
+            set {
+                _badge = value;
+
+                badge_changed (value);
+            }
+        }
+        public signal void badge_changed (uint label);
+
+        public SidebarRowModel (string label) {
+            Object(label: label);
+        }
+        
+        public SidebarRowModel.with_icon_name (string label, string icon_name) {
+            Object(label: label, icon_name: icon_name);
+        }
+        
+        construct {
+            connect_signals ();
+        }
+        
+        private void connect_signals () {
+            hide.connect (handle_hide);
+            show.connect (handle_show);
+        }
+        
+        private void handle_hide () {
+            visible = false;
+        }
+        
+        private void handle_show () {
+            visible = true;
+        }
+
+        public void register_parent_store (SidebarStore parent_store) {
+            this.parent_store = parent_store;
+
+            parent_store.level_changed.connect(handle_parent_store_level_changed);
+
+            handle_parent_store_level_changed (parent_store.level);
+        }
+
+        public void unregister_parent_store () {
+            parent_store.level_changed.disconnect (handle_parent_store_level_changed);
+
+            parent_store = null;
+        }
+        
+
+        private void handle_parent_store_level_changed (uint level) {
+            this.level = level+1;
+        }
+    }
+    
+}

--- a/lib/Widgets/Sidebar/SidebarRowModel.vala
+++ b/lib/Widgets/Sidebar/SidebarRowModel.vala
@@ -21,9 +21,9 @@
 namespace Granite.Widgets {
     public class SidebarRowModel : GLib.Object {
         public SidebarStore parent_store { get; private set; }
-        
+
         public bool visible { get; private set; default = true; }
-        
+
         // AZ:  I'm not sure how to prevent these from being called from the
         //      outside. It will be overrided as soon as an expand/contract
         //      happens on a parent row.
@@ -39,12 +39,12 @@ namespace Granite.Widgets {
             }
             set {
                 _level = value;
-                
+
                 level_changed (value);
             }
         }
         public signal void level_changed (uint level);
-        
+
         private double _indicator_level = -1;
         public double indicator_level {
             get {
@@ -65,13 +65,13 @@ namespace Granite.Widgets {
             }
             set {
                 _busy = value;
-                
+
                 busy_changed (value);
             }
         }
         public signal void busy_changed (bool busy);
 
-        
+
         private string _label;
         public string label {
             get {
@@ -79,12 +79,12 @@ namespace Granite.Widgets {
             }
             construct set {
                 _label = value;
-                
+
                 label_changed (value);
             }
         }
         public signal void label_changed (string label);
-        
+
         private string _tooltip_text;
         public string tooltip_text {
             get {
@@ -92,38 +92,68 @@ namespace Granite.Widgets {
             }
             construct set {
                 _tooltip_text = value;
-                
+
                 tooltip_text_changed (value);
             }
         }
         public signal void tooltip_text_changed (string tooltip_text);
-        
+
         private string _icon_name = "";
         public string icon_name {
             get {
                 return _icon_name;
             }
             set {
+                _icon_pixbuf = null;
                 _icon_name = value;
-                
+
                 icon_name_changed (value);
             }
         }
         public signal void icon_name_changed (string icon_name);
-        
+
         private string _action_icon_name = "";
         public string action_icon_name {
             get {
                 return _action_icon_name;
             }
             set {
+                _action_icon_pixbuf = null;
                 _action_icon_name = value;
 
                 action_icon_name_changed (value);
             }
         }
         public signal void action_icon_name_changed (string label);
-        
+
+        private Gdk.Pixbuf _icon_pixbuf = null;
+        public Gdk.Pixbuf icon_pixbuf {
+            get {
+                return _icon_pixbuf;
+            }
+            set {
+                _icon_name = null;
+                _icon_pixbuf = value;
+
+                icon_pixbuf_changed (value);
+            }
+        }
+        public signal void icon_pixbuf_changed (Gdk.Pixbuf icon_pixbuf);
+
+        private Gdk.Pixbuf _action_icon_pixbuf = null;
+        public Gdk.Pixbuf action_icon_pixbuf {
+            get {
+                return _action_icon_pixbuf;
+            }
+            set {
+                _action_icon_name = null;
+                _action_icon_pixbuf = value;
+
+                action_icon_pixbuf_changed (value);
+            }
+        }
+        public signal void action_icon_pixbuf_changed (Gdk.Pixbuf action_icon_pixbuf);
+
         private bool _action_visible;
         public bool action_visible {
             get {
@@ -153,24 +183,28 @@ namespace Granite.Widgets {
         public SidebarRowModel (string label) {
             Object(label: label);
         }
-        
+
         public SidebarRowModel.with_icon_name (string label, string icon_name) {
             Object(label: label, icon_name: icon_name);
         }
-        
+
+        public SidebarRowModel.with_icon_pixbuf (string label, Gdk.Pixbuf icon_pixbuf) {
+            Object (label: label, icon_pixbuf: icon_pixbuf);
+        }
+
         construct {
             connect_signals ();
         }
-        
+
         private void connect_signals () {
             hide.connect (handle_hide);
             show.connect (handle_show);
         }
-        
+
         private void handle_hide () {
             visible = false;
         }
-        
+
         private void handle_show () {
             visible = true;
         }
@@ -188,11 +222,11 @@ namespace Granite.Widgets {
 
             parent_store = null;
         }
-        
+
 
         private void handle_parent_store_level_changed (uint level) {
             this.level = level+1;
         }
     }
-    
+
 }

--- a/lib/Widgets/Sidebar/SidebarStore.vala
+++ b/lib/Widgets/Sidebar/SidebarStore.vala
@@ -1,3 +1,23 @@
+/*
+* Copyright (c) 2016 elementary LLC (https://launchpad.net/granite)
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public
+* License as published by the Free Software Foundation; either
+* version 2 of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* General Public License for more details.
+*
+* You should have received a copy of the GNU General Public
+* License along with this program; if not, write to the
+* Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+* Boston, MA 02111-1307, USA.
+*
+*/
+
 namespace Granite.Widgets {
     public class SidebarStore : GLib.Object, GLib.ListModel {
         

--- a/lib/Widgets/Sidebar/SidebarStore.vala
+++ b/lib/Widgets/Sidebar/SidebarStore.vala
@@ -1,0 +1,207 @@
+namespace Granite.Widgets {
+    public class SidebarStore : GLib.Object, GLib.ListModel {
+        
+        private uint _level;
+        public uint level {
+            default = 0;
+            get {
+                return _level;
+            }
+            set {
+                _level = value;
+                level_changed (value);
+            }
+        }
+
+        public signal void level_changed (uint level);
+        public signal void item_added (SidebarRowModel item);
+
+        private Gee.ArrayList<SidebarRowModel> _full_list = new Gee.ArrayList<SidebarRowModel> ();
+        public Gee.Collection<SidebarRowModel> full_list {
+            owned get {
+                // Create a copy of the children so that it's safe to iterate it
+                // (e.g. by using foreach) while removing items.
+                var full_list_copy = new Gee.ArrayList<SidebarRowModel> ();
+                full_list_copy.add_all (_full_list);
+                return full_list_copy;
+            }
+        }
+
+        private Gee.ArrayList<SidebarRowModel> _root_items = new Gee.ArrayList<SidebarRowModel> ();
+        public Gee.Collection<SidebarRowModel> root_items {
+            owned get {
+                // Create a copy of the children so that it's safe to iterate it
+                // (e.g. by using foreach) while removing items.
+                var root_list_copy = new Gee.ArrayList<SidebarRowModel> ();
+                root_list_copy.add_all (_root_items);
+                return root_list_copy;
+            }
+        }
+    
+        public SidebarStore () { }
+
+        public Object? get_item (uint position) {
+            return _full_list.get((int) position);
+        }
+
+        public Type get_item_type () {
+            return typeof(SidebarRowModel);
+        }
+
+        public uint get_n_items () {
+            return (uint) _full_list.size;
+        }
+
+        public Object? get_object (uint position) {
+            return _full_list.get((int) position);
+        }
+        
+        public void append (SidebarRowModel item) {
+            assert (item != null);
+
+            _root_items.add (item);
+
+            handle_addition (_root_items.size - 1, item);
+        }
+
+        public void insert (uint position, SidebarRowModel item) {
+            assert (item != null);
+
+            _root_items.insert ((int) position, item);
+
+            handle_addition (position, item);
+        }
+
+        public void handle_addition (uint position, SidebarRowModel item) {
+            assert (item != null && position <= _root_items.size);
+
+            item.register_parent_store (this);
+            
+            item_added (item);
+
+            regenerate_full_list ();
+            
+            uint items_so_far = 0;
+
+            items_so_far = full_list_items_until_root_items_position (position);
+
+            if (item is SidebarParentRowModel) {
+                var expandable_item = (SidebarParentRowModel) item;
+
+                expandable_item.items_changed.connect ((position, removed, added) => {
+                    handle_items_changed (item, position, removed, added);
+                });
+
+                items_changed (items_so_far, 0, 1 + expandable_item.children.get_n_items ());
+            } else {
+                items_changed (items_so_far, 0, 1);
+            }
+        }
+
+        public void remove_at (uint position) {
+            assert (position < _root_items.size);
+
+            handle_removal (position);
+        }
+
+        public void remove (SidebarRowModel item) {
+            var index = _root_items.index_of (item);
+            
+            assert (index != -1);
+
+            handle_removal (index);
+        }
+        
+        private void handle_removal (uint position) {
+            assert (position < _root_items.size);
+
+            uint children_count;
+            
+            var item = _root_items.get ((int) position);
+
+            item.unregister_parent_store ();
+
+            _root_items.remove (item);
+
+            regenerate_full_list ();
+
+            if (item is SidebarParentRowModel) {
+                var expandable_item = (SidebarParentRowModel) item;
+
+                items_changed (position, 1 + expandable_item.children.get_n_items (), 0);
+            } else {
+                items_changed (position, 1, 0);
+            }
+        }
+
+        public void remove_all () {
+            var size = _full_list.size;
+            
+            foreach (var root_item in _root_items) {
+                root_item.unregister_parent_store ();
+            }
+
+            _root_items.clear ();
+
+            regenerate_full_list ();
+
+            items_changed (0, size, 0);
+        }
+        
+        private void handle_items_changed (SidebarRowModel item, uint position, uint removed, uint added) {
+            regenerate_full_list ();
+
+            uint items_offset = 0;
+
+            for (uint i = 0; i < _root_items.index_of (item); i++) {
+                var child = _root_items.get((int) i);
+
+                if (child is SidebarParentRowModel) {
+                    var expandable_child = (SidebarParentRowModel) child;
+                    items_offset += 1 + expandable_child.children.get_n_items ();
+                } else {
+                    items_offset += 1;
+                }
+            }
+
+            items_offset += 1; // Offsetting for the root_item
+
+            items_changed (items_offset + position, removed, added);
+        }
+
+        private void regenerate_full_list () {
+            // It's easier and simpler to regenerate everything every time like 
+            // this than keep track of everything.
+
+            _full_list.clear ();
+
+            foreach (var root_item in _root_items) {
+                _full_list.add (root_item);
+
+                if (root_item is SidebarParentRowModel) {
+                    var expandable_item = (SidebarParentRowModel) root_item;
+                    _full_list.add_all (expandable_item.children.full_list);
+                }
+            }
+        }
+        
+        // How many items does the full_list contain before the item at this position in _root_items?
+        private uint full_list_items_until_root_items_position (uint position) {
+            uint items_so_far = 0;
+
+            for (uint i = 0; i < position; i++) {
+                var child = _root_items.get((int) i);
+                
+                if (child is SidebarParentRowModel) {
+                    var expandable_child = (SidebarParentRowModel) child;
+                    items_so_far += 1 + expandable_child.children.get_n_items ();
+                } else {
+                    items_so_far += 1;
+                }
+            }
+            
+            return items_so_far;
+        }
+
+    }
+}


### PR DESCRIPTION
Work in progress. I'm currently looking through the [old launchpad thread](https://code.launchpad.net/~matzipan/granite/sidebar-widget-improvements/+merge/305284) to figure out what still neads to be done.

* [ ] Fix pixbuf with hidpi
* [ ] Add scroll box
* [ ] Custom context menus
* [ ] Remember expansion state
* [ ] Comments for valadocs
* [ ] Drag and drop https://blog.gtk.org/2017/04/23/drag-and-drop-in-lists/
* [ ] Write tests for store
* [ ] Use workaround: https://gist.github.com/matzipan/d4e78f3e5ea95890f403871b50d63b76#on-inheritance-of-constructors
* [x] Demo should reflect mail/files/scratch use-cases
* [x] Custom pixbuf icons

CSS required:
```
.sidebar .row-label { padding-left: 0; }
.sidebar .icon { padding-right: 5px; }
.sidebar .indicator-present .row-label { padding-bottom: 0px; padding-top: 2px; }

GraniteWidgetsIndicatorBar,
GraniteWidgetsIndicatorBar:selected,
GraniteWidgetsIndicatorBar:selected:focus {
    background-color: @base_color;
    border: 1px solid alpha (#000, 0.15);
    box-shadow: 0 1px 0 alpha (#fff, 0.25);
    border-radius: 2px;
}

GraniteWidgetsIndicatorBar.fill,
GraniteWidgetsIndicatorBar.fill:hover,
GraniteWidgetsIndicatorBar.fill:selected,
GraniteWidgetsIndicatorBar.fill:selected:focus {
    background-image: none;
    background-color: mix (@colorAccent, @base_color, 0.25);
}

GraniteWidgetsIndicatorBar.fill {
    border: none;
}
```

There appears to be an issue which might need checking futher with headers. Open the demo, focus on another window and now hover (without clicking) over the demo. The label will be at 100% opacity. The other rows don't do that. 