### PR TITLE
Switch WelcomeButton from button_release_event to clicked

### DIFF
--- a/lib/Widgets/Welcome.vala
+++ b/lib/Widgets/Welcome.vala
@@ -190,10 +190,9 @@ public class Granite.Widgets.Welcome : Gtk.EventBox {
         children.append (button);
         options.pack_start (button, false, false, 0);
 
-        button.button_release_event.connect (() => {
+        button.clicked.connect (() => {
             int index = this.children.index (button);
             activated (index); // send signal
-            return false;
         });
 
         return this.children.index (button);


### PR DESCRIPTION
This makes WelcomeButton behave more similarly to normal buttons; instead of looking for the release event, we look for the click event. 

Gtk handles this slightly differently by requiring the press and release to be performed inside of the widget, which has a side effect of allowing a sort of cancel when you press, then drag outside the widget, then release.