### PR TITLE
Demo: Replace Welcome with a StackSidebar

### DIFF
--- a/demo/CMakeLists.txt
+++ b/demo/CMakeLists.txt
@@ -20,6 +20,7 @@ vala_precompile (VALA_C ${EXEC_NAME}
     Views/SourceListView.vala
     Views/StorageView.vala
     Views/ToastView.vala
+    Views/WelcomeView.vala
 CUSTOM_VAPIS
     ${CMAKE_CURRENT_BINARY_DIR}/../lib/${PKG_NAME}.vapi
 PACKAGES

--- a/demo/GraniteDemo.vala
+++ b/demo/GraniteDemo.vala
@@ -26,9 +26,6 @@
 
 public class Granite.Demo : Granite.Application {
     Gtk.Window window;
-    Gtk.Paned main_paned;
-    Gtk.Stack main_stack;
-    Gtk.Button home_button;
 
     /**
      * Basic app information for Granite.Application. This is used by the About dialog.
@@ -69,8 +66,6 @@ public class Granite.Demo : Granite.Application {
         window.window_position = Gtk.WindowPosition.CENTER;
         add_window (window);
 
-        main_paned = new Gtk.Paned (Gtk.Orientation.HORIZONTAL);
-
         create_headerbar ();
 
         var alert_view = new AlertViewView ();
@@ -82,26 +77,30 @@ public class Granite.Demo : Granite.Application {
         var source_list_view = new SourceListView ();
         var storage_view = new StorageView ();
         var toast_view = new ToastView ();
+        var welcome = new WelcomeView ();
 
-        main_stack = new Gtk.Stack ();
-        main_stack.transition_type = Gtk.StackTransitionType.SLIDE_LEFT_RIGHT;
+        var main_stack = new Gtk.Stack ();
+        main_stack.add_titled (welcome, "welcome", "Welcome");
+        main_stack.add_titled (alert_view, "alert", "AlertView");
+        main_stack.add_titled (avatar_view, "avatar", "Avatar");
+        main_stack.add_titled (date_time_picker_view, "pickers", "DatePicker & TimePicker");
+        main_stack.add_titled (dynamic_notebook_view, "dynamictab", "DynamicNotebook");
+        main_stack.add_titled (mode_button_view, "modebutton", "ModeButton");
+        main_stack.add_titled (overlaybar_view, "overlaybar", "OverlayBar");
+        main_stack.add_titled (source_list_view, "sourcelist", "SourceList");
+        main_stack.add_titled (storage_view, "storage", "StorageBar");
+        main_stack.add_titled (toast_view, "toasts", "Toast");
 
-        create_welcome ();
+        var stack_sidebar = new Gtk.StackSidebar ();
+        stack_sidebar.stack = main_stack;
 
-        main_stack.add_named (alert_view, "alert");
-        main_stack.add_named (avatar_view, "avatar");
-        main_stack.add_named (date_time_picker_view, "pickers");
-        main_stack.add_named (dynamic_notebook_view, "dynamictab");
-        main_stack.add_named (mode_button_view, "modebutton");
-        main_stack.add_named (overlaybar_view, "overlaybar");
-        main_stack.add_named (source_list_view, "sourcelist");
-        main_stack.add_named (storage_view, "storage");
-        main_stack.add_named (toast_view, "toasts");
+        var paned = new Gtk.Paned (Gtk.Orientation.HORIZONTAL);
+        paned.add1 (stack_sidebar);
+        paned.add2 (main_stack);
 
-        window.add (main_stack);
+        window.add (paned);
         window.set_default_size (800, 550);
         window.show_all ();
-        home_button.hide ();
     }
 
     private void create_headerbar () {
@@ -114,79 +113,14 @@ public class Granite.Demo : Granite.Application {
         about_button.tooltip_text = "About this application";
         about_button.clicked.connect (() => {show_about (window);});
 
-        home_button = new Gtk.Button.with_label ("Back");
-        home_button.get_style_context ().add_class ("back-button");
-        home_button.valign = Gtk.Align.CENTER;
-        home_button.clicked.connect (() => {
-            main_stack.set_visible_child_name ("welcome");
-            home_button.hide ();
-        });
-
         var primary_color_button = new Gtk.ColorButton.with_rgba ({ 222, 222, 222, 255 });
         primary_color_button.color_set.connect (() => {
             Granite.Widgets.Utils.set_color_primary (window, primary_color_button.rgba);
         });
 
-        headerbar.pack_start (home_button);
         headerbar.pack_end (about_button);
         headerbar.pack_end (primary_color_button);
         window.set_titlebar (headerbar);
-    }
-
-    private void create_welcome () {
-        var welcome = new Granite.Widgets.Welcome ("Sample Window", "This is a demo of the Granite library.");
-        welcome.append ("office-calendar", "TimePicker & DatePicker", "Widgets that allows users to easily pick a time or a date.");
-        welcome.append ("tag-new", "SourceList", "A widget that can display a list of items organized in categories.");
-        welcome.append ("object-inverse", "ModeButton", "This widget is a multiple option modal switch");
-        welcome.append ("document-open", "DynamicNotebook", "Tab bar widget designed for a variable number of tabs.");
-        welcome.append ("dialog-warning", "AlertView", "A View showing that an action is required to function.");
-        welcome.append ("drive-harddisk", "Storage", "Small bar indicating the remaining amount of space.");
-        welcome.append ("dialog-information", _("Toasts"), _("Simple in-app notifications"));
-        welcome.append ("dialog-information", "OverlayBar", "A floating status bar that displays a single line of text");
-        welcome.append ("avatar-default", "Avatar", "A styled avatar from an image ");
-        welcome.activated.connect ((index) => {
-            switch (index) {
-                case 0:
-                    home_button.show ();
-                    main_stack.set_visible_child_name ("pickers");
-                    break;
-                case 1:
-                    home_button.show ();
-                    main_stack.set_visible_child_name ("sourcelist");
-                    break;
-                case 2:
-                    home_button.show ();
-                    main_stack.set_visible_child_name ("modebutton");
-                    break;
-                case 3:
-                    home_button.show ();
-                    main_stack.set_visible_child_name ("dynamictab");
-                    break;
-                case 4:
-                    home_button.show ();
-                    main_stack.set_visible_child_name ("alert");
-                    break;
-                case 5:
-                    home_button.show ();
-                    main_stack.set_visible_child_name ("storage");
-                    break;
-                case 6:
-                    home_button.show ();
-                    main_stack.set_visible_child_name ("toasts");
-                    break;
-                case 7:
-                    home_button.show ();
-                    main_stack.set_visible_child_name ("overlaybar");
-                    break;
-                case 8:
-                    home_button.show ();
-                    main_stack.set_visible_child_name ("avatar");
-                    break;
-            }
-        });
-        var scrolled = new Gtk.ScrolledWindow (null, null);
-        scrolled.add (welcome);
-        main_stack.add_named (scrolled, "welcome");
     }
 
     public static int main (string[] args) {

--- a/demo/Views/SourceListView.vala
+++ b/demo/Views/SourceListView.vala
@@ -24,11 +24,7 @@
  *              Corentin Noël <corentin@elementary.io>
  */
 
-public class SourceListView : Gtk.Paned {
-    public SourceListView () {
-        Object (orientation: Gtk.Orientation.HORIZONTAL);
-    }
-
+public class SourceListView : Gtk.Frame {
     construct {
         var music_item = new Granite.Widgets.SourceList.Item ("Music");
         music_item.badge = "1";
@@ -72,9 +68,13 @@ public class SourceListView : Gtk.Paned {
 
         var label = new Gtk.Label ("No selected item");
 
-        position = 150;
-        pack1 (source_list, false, false);
-        add2 (label);
+        var paned = new Gtk.Paned (Gtk.Orientation.HORIZONTAL);
+        paned.position = 130;
+        paned.pack1 (source_list, false, false);
+        paned.add2 (label);
+
+        margin = 48;
+        add (paned);
 
         source_list.item_selected.connect ((item) => {
             if (item == null) {

--- a/demo/Views/WelcomeView.vala
+++ b/demo/Views/WelcomeView.vala
@@ -30,7 +30,7 @@ public class WelcomeView : Gtk.Grid {
             switch (index) {
                 case 0:
                     try {
-                        AppInfo.launch_default_for_uri ("https://valadoc.org", null);
+                        AppInfo.launch_default_for_uri ("https://valadoc.org/granite/Granite.html", null);
                     } catch (Error e) {
                         warning ("%s\n", e.message);
                     }

--- a/demo/Views/WelcomeView.vala
+++ b/demo/Views/WelcomeView.vala
@@ -1,0 +1,54 @@
+// -*- Mode: vala; indent-tabs-mode: nil; tab-width: 4 -*-
+/*-
+ * Copyright (c) 2011-2017 elementary LLC. (https://elementary.io)
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ * Authored by: Lucas Baudin <xapantu@gmail.com>
+ *              Jaap Broekhuizen <jaapz.b@gmail.com>
+ *              Victor Eduardo <victoreduardm@gmal.com>
+ *              Tom Beckmann <tom@elementary.io>
+ *              Corentin Noël <corentin@elementary.io>
+ */
+
+public class WelcomeView : Gtk.Grid {
+    construct {
+        var welcome = new Granite.Widgets.Welcome ("Granite Demo", "This is a demo of the Granite library.");
+        welcome.append ("text-x-vala", "Visit Valadoc", "The canonical source for Vala API references.");
+        welcome.append ("text-x-source", "Get Granite Source", "Granite's source code is hosted on GitHub.");
+
+        add (welcome);
+
+        welcome.activated.connect ((index) => {
+            switch (index) {
+                case 0:
+                    try {
+                        AppInfo.launch_default_for_uri ("https://valadoc.org", null);
+                    } catch (Error e) {
+                        warning ("%s\n", e.message);
+                    }
+                    break;
+                case 1:
+                    try {
+                        AppInfo.launch_default_for_uri ("https://github.com/elementary/granite", null);
+                    } catch (Error e) {
+                        warning ("%s\n", e.message);
+                    }
+                    break;
+            }
+        });
+    }
+}

--- a/demo/Views/WelcomeView.vala
+++ b/demo/Views/WelcomeView.vala
@@ -32,15 +32,17 @@ public class WelcomeView : Gtk.Grid {
                     try {
                         AppInfo.launch_default_for_uri ("https://valadoc.org/granite/Granite.html", null);
                     } catch (Error e) {
-                        warning ("%s\n", e.message);
+                        warning (e.message);
                     }
+
                     break;
                 case 1:
                     try {
                         AppInfo.launch_default_for_uri ("https://github.com/elementary/granite", null);
                     } catch (Error e) {
-                        warning ("%s\n", e.message);
+                        warning (e.message);
                     }
+
                     break;
             }
         });

--- a/demo/Views/WelcomeView.vala
+++ b/demo/Views/WelcomeView.vala
@@ -1,6 +1,6 @@
 // -*- Mode: vala; indent-tabs-mode: nil; tab-width: 4 -*-
 /*-
- * Copyright (c) 2011-2017 elementary LLC. (https://elementary.io)
+ * Copyright (c) 2017 elementary LLC. (https://elementary.io)
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -16,12 +16,6 @@
  * License along with this library; if not, write to the
  * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
  * Boston, MA 02111-1307, USA.
- *
- * Authored by: Lucas Baudin <xapantu@gmail.com>
- *              Jaap Broekhuizen <jaapz.b@gmail.com>
- *              Victor Eduardo <victoreduardm@gmal.com>
- *              Tom Beckmann <tom@elementary.io>
- *              Corentin Noël <corentin@elementary.io>
  */
 
 public class WelcomeView : Gtk.Grid {


### PR DESCRIPTION
The number of items has really outgrown the welcome widget. This replaces using the welcome for navigation with a Gtk.StackSidebar and creates a new Welcome view with only two items.

I also added a frame and some margin to SourceList because it looked freakin weird
![screenshot from 2017-05-07 17 45 46](https://cloud.githubusercontent.com/assets/7277719/25786600/05332728-334d-11e7-829a-9f8c40ccc6bf.png)

