### PR TITLE
OverlayBar.vala: bump version number on deprecation

### DIFF
--- a/lib/Widgets/OverlayBar.vala
+++ b/lib/Widgets/OverlayBar.vala
@@ -61,7 +61,7 @@ public class Granite.Widgets.OverlayBar : Gtk.EventBox {
     /**
      * Status text displayed inside the Overlay Bar.
      */
-    [Version (deprecated = true, deprecated_since = "0.4.1", replacement = "OverlayBar.label")]
+    [Version (deprecated = true, deprecated_since = "0.4.2", replacement = "OverlayBar.label")]
     public string status {
         set {
            status_label.label = value;


### PR DESCRIPTION
This actually got merged after 0.4.1 was released so this should be 0.4.2 which will (probably) be the next version including this deprecation