### PR TITLE
DynamicNotebook: fixed return_if_fail in non-void method insert_tab leading to a build error on macOS

### DIFF
--- a/lib/Widgets/DynamicNotebook.vala
+++ b/lib/Widgets/DynamicNotebook.vala
@@ -1135,7 +1135,7 @@ namespace Granite.Widgets {
         }
 
         public uint insert_tab (Tab tab, int index) {
-            return_if_fail (tabs.index (tab) < 0);
+            return_val_if_fail (tabs.index (tab) < 0, 0);
 
             var i = 0;
             if (index <= -1)


### PR DESCRIPTION
`DynamicNotebook.insert_tab` returns an unsigned integer, but uses `GLib.return_if_fail` instead of the correct `GLib.return_val_if_fail`. Presumably this would only result in a warning on a native elementaryOS build, but on macOS with clang, this produces a compile error instead:

```
.../granite/build/lib/Widgets/DynamicNotebook.c:4159:2: error:
      non-void function 'granite_widgets_dynamic_notebook_insert_tab' should
      return a value [-Wreturn-type]
        g_return_if_fail (_tmp3_ < 0);
```

This error blocked granite from being included in Homebrew in the past; see https://github.com/Homebrew/homebrew-core/pull/1139. (The following is not in the commit message.) The people who first noticed this error thought that the official granite repository was on Launchpad and [reported it there](https://bugs.launchpad.net/granite/+bug/1581531), then wondered why there was no response. I found the issue because I wanted to build [this](https://github.com/Philip-Scott/Spice-up) and [this](https://github.com/parnold-x/nasc) on macOS, which both depend on granite.

Thanks to TingPing, baedert, and benwaffle in irc.gimp.net #gtk+ for help identifying the correct way to fix this bug. And thanks for reviewing this PR!