### PR TITLE
Deprecate About Dialog

### DIFF
--- a/demo/GraniteDemo.vala
+++ b/demo/GraniteDemo.vala
@@ -26,48 +26,20 @@
 
 public class Granite.Demo : Granite.Application {
     /**
-     * Basic app information for Granite.Application. This is used by the About dialog.
+     * Basic app information for Granite.Application.
      */
     construct {
         application_id = "org.pantheon.granite.demo";
         flags = ApplicationFlags.FLAGS_NONE;
 
         program_name = "Granite Demo";
-        app_years = "2011-2017";
 
         build_version = "0.4.1";
         app_icon = "applications-interfacedesign";
-        main_url = "https://github.com/elementary/granite";
-        bug_url = "https://github.com/elementary/granite/issues";
-        help_url = "https://elementaryos.stackexchange.com/questions/tagged/development";
-        translate_url = "https://l10n.elementary.io/projects/desktop/granite";
-
-        about_documenters = { null };
-        about_artists = { "Daniel Foré <daniel@elementary.io>" };
-        about_authors = {
-            "Maxwell Barvian <mbarvian@gmail.com>",
-            "Daniel Foré <daniel@elementary.io>",
-            "Avi Romanoff <aviromanoff@gmail.com>",
-            "Lucas Baudin <xapantu@gmail.com>",
-            "Victor Eduardo <victoreduardm@gmail.com>",
-            "Tom Beckmann <tombeckmann@online.de>",
-            "Corentin Noël <corentin@elementary.io>"
-        };
-
-        about_comments = "A demo of the Granite toolkit";
-        about_translators = _("translator-credits");
-        about_license_type = Gtk.License.GPL_3_0;
     }
 
     public override void activate () {
         var window = new Gtk.Window ();
-
-        var about_button = new Gtk.Button.from_icon_name ("dialog-information", Gtk.IconSize.LARGE_TOOLBAR);
-        about_button.tooltip_text = "About this application";
-
-        var headerbar = new Gtk.HeaderBar ();
-        headerbar.show_close_button = true;
-        headerbar.pack_end (about_button);
 
         var alert_view = new AlertViewView ();
         var avatar_view = new AvatarView ();
@@ -104,15 +76,10 @@ public class Granite.Demo : Granite.Application {
         window.add (paned);
         window.set_default_size (900, 600);
         window.set_size_request (750, 500);
-        window.set_titlebar (headerbar);
         window.title = "Granite Demo";
         window.show_all ();
 
         add_window (window);
-
-        about_button.clicked.connect (() => {
-            show_about (window);
-        });
     }
 
     public static int main (string[] args) {

--- a/lib/Application.vala
+++ b/lib/Application.vala
@@ -34,7 +34,6 @@ namespace Granite {
          * The user facing name of the application. This name is used
          * throughout the application and should be capitalized correctly.
          */
-        [Version (deprecated = true, deprecated_since = "0.4.2", replacement = "")]
         public string program_name;
 
         /**

--- a/lib/Application.vala
+++ b/lib/Application.vala
@@ -34,6 +34,7 @@ namespace Granite {
          * The user facing name of the application. This name is used
          * throughout the application and should be capitalized correctly.
          */
+        [Version (deprecated = true, deprecated_since = "0.4.2", replacement = "")]
         public string program_name;
 
         /**
@@ -47,7 +48,9 @@ namespace Granite {
          * Years that the copyright extends to. Usually from the start
          * of the project to the most recent modification to it.
          */
+        [Version (deprecated = true, deprecated_since = "0.4.2", replacement = "")]
         public string app_copyright;
+        [Version (deprecated = true, deprecated_since = "0.4.2", replacement = "")]
         public string app_years;
 
         /**
@@ -58,6 +61,7 @@ namespace Granite {
          * The name should not include the full path or file extension.
          * WRONG: /usr/share/icons/myicon.png RIGHT: myicon
          */
+        [Version (deprecated = true, deprecated_since = "0.4.2", replacement = "")]
         public string app_icon;
 
         /**
@@ -75,6 +79,7 @@ namespace Granite {
          * If the application has no homepage, one should be created on
          * launchpad.net.
          */
+        [Version (deprecated = true, deprecated_since = "0.4.2", replacement = "")]
         public string main_url;
 
         /**
@@ -83,6 +88,7 @@ namespace Granite {
          * If the application does not have a bug tracker, one should be
          * created on launchpad.net.
          */
+        [Version (deprecated = true, deprecated_since = "0.4.2", replacement = "")]
         public string bug_url;
 
         /**
@@ -90,6 +96,7 @@ namespace Granite {
          *
          * Launchpad offers a QA service if one is needed.
          */
+        [Version (deprecated = true, deprecated_since = "0.4.2", replacement = "")]
         public string help_url;
 
         /**
@@ -97,34 +104,41 @@ namespace Granite {
          *
          * Launchad offers a translation service if one is necessary.
          */
+        [Version (deprecated = true, deprecated_since = "0.4.2", replacement = "")]
         public string translate_url;
 
         /**
          * Full names of the application authors for the about dialog.
          */
+        [Version (deprecated = true, deprecated_since = "0.4.2", replacement = "")]
         public string[] about_authors = {};
 
         /**
          * Full names of documenters of the app for the about dialog.
          */
+        [Version (deprecated = true, deprecated_since = "0.4.2", replacement = "")]
         public string[] about_documenters = {};
 
         /**
          * Names of the designers of the application's user interface.
          */
+        [Version (deprecated = true, deprecated_since = "0.4.2", replacement = "")]
         public string[] about_artists = {};
-
+        [Version (deprecated = true, deprecated_since = "0.4.2", replacement = "")]
         public string about_comments;
 
         /**
          * Names of the translators of the application.
          */
+        [Version (deprecated = true, deprecated_since = "0.4.2", replacement = "")]
         public string about_translators;
 
         /**
          * The copyright license that the work is distributed under.
          */
+        [Version (deprecated = true, deprecated_since = "0.4.2", replacement = "")]
         public string about_license;
+        [Version (deprecated = true, deprecated_since = "0.4.2", replacement = "")]
         public Gtk.License about_license_type;
 
         /**
@@ -144,8 +158,6 @@ namespace Granite {
             Granite.Services.Logger.DisplayLevel = Granite.Services.LogLevel.WARN;
 
             Intl.bindtextdomain (exec_name, build_data_dir + "/locale");
-
-            add_actions ();
         }
 
 #if LINUX
@@ -179,22 +191,13 @@ namespace Granite {
 
             set_options ();
 
-            if (ABOUT) {
-                Gtk.init (ref args);
-                handle_about_parameter ();
-
-                return Posix.EXIT_SUCCESS;
-            }
-
             return base.run (args);
         }
 
         protected static bool DEBUG = false;
-        protected static bool ABOUT = false;
 
         protected const OptionEntry[] options = {
             { "debug", 'd', 0, OptionArg.NONE, out DEBUG, "Enable debug logging", null },
-            { "about", 'a', 0, OptionArg.NONE, out ABOUT, "Show About dialog", null },
             { null }
         };
 
@@ -260,64 +263,6 @@ namespace Granite {
                                                "help", help_url,
                                                "translate", translate_url,
                                                "bug", bug_url);
-        }
-
-        /* Allows reusing the About dialog */
-        private Gtk.Window about_dialog_parent = null;
-
-        private void add_actions () {
-            /* Actions are always executed in the primary instance, provided
-               that the application was registered.
-               Take advantage of this by showing the About dialog using the
-               main instance, saving memory. */
-            var show_about_action = new SimpleAction ("show-about-dialog", null);
-
-            show_about_action.activate.connect (() => {
-                hold ();
-
-                debug ("The show-about-dialog action was activated");
-
-                if (this.about_dialog_parent == null)
-                    this.about_dialog_parent = new Gtk.Window ();
-
-                show_about (this.about_dialog_parent);
-
-                release ();
-            });
-
-            add_action (show_about_action);
-        }
-
-        private void handle_about_parameter () {
-            try {
-                register ();
-            } catch (Error error) {
-                warning ("Couldn't register application: %s", error.message);
-            }
-
-            activate_action ("show-about-dialog", null);
-
-            if (!this.is_remote) {
-                /* This means that the primary instance was created by running
-                   "app --about".
-                   Manually set up exit conditions and run the main loop of the
-                   application.
-                   This is needed to prevent weird stuff from happening if the
-                   actual application is opened while this is running. */
-                Gtk.Widget about_dialog = this.about_dialog_parent.get_data ("gtk-about-dialog");
-
-                about_dialog.hide.connect (() => {
-                    if (get_windows () == null)
-                        Gtk.main_quit ();
-                });
-
-                window_removed.connect (() => {
-                    if (get_windows () == null)
-                        Gtk.main_quit ();
-                });
-
-                Gtk.main ();
-            }
         }
     }
 }

--- a/lib/Application.vala
+++ b/lib/Application.vala
@@ -237,6 +237,7 @@ namespace Granite {
          *
          * @param parent This widget is the window that is calling the about page being created.
          */
+        [Version (deprecated = true, deprecated_since = "0.4.2", replacement = "")]
         public virtual void show_about (Gtk.Widget parent) {
             assert (parent is Gtk.Window);
 

--- a/lib/Widgets/AboutDialog.vala
+++ b/lib/Widgets/AboutDialog.vala
@@ -23,6 +23,7 @@ namespace Granite.Widgets {
 
     /**
      * This class makes an about dialog which goes in the App Menu on most apps.
+     * This class is deprecated. Applications should instead provide an Appstream appdata.xml file to describe their metadata
      *
      * {{../../doc/images/AboutDialog.png}}
      */

--- a/lib/Widgets/AboutDialog.vala
+++ b/lib/Widgets/AboutDialog.vala
@@ -26,6 +26,7 @@ namespace Granite.Widgets {
      *
      * {{../../doc/images/AboutDialog.png}}
      */
+    [Version (deprecated = true, deprecated_since = "0.4.2", replacement = "")]
     public class AboutDialog : Granite.GtkPatch.AboutDialog {
         /**
          * The URL for the link to the website of the program.


### PR DESCRIPTION
Since the plan is that going forward all apps should have this data in their appdata.xml (and thus AppCenter) instead