### PR TITLE
Reload and resize Avatar on DPI change

### DIFF
--- a/lib/Widgets/Avatar.vala
+++ b/lib/Widgets/Avatar.vala
@@ -64,7 +64,7 @@ public class Granite.Widgets.Avatar : Gtk.EventBox {
 
     private void load_image (string filepath, int pixel_size) {
         try {
-            var size = pixel_size * get_style_context ().get_scale ();
+            var size = pixel_size * get_scale_factor ();
             pixbuf = new Gdk.Pixbuf.from_file_at_size (filepath, size, size);
         } catch (Error e) {
             show_default (pixel_size);

--- a/lib/Widgets/Avatar.vala
+++ b/lib/Widgets/Avatar.vala
@@ -28,6 +28,10 @@ public class Granite.Widgets.Avatar : Gtk.EventBox {
     private const int EXTRA_MARGIN = 4;
     private bool draw_theme_background = true;
 
+    private bool is_default = false;
+    private string? orig_filename = null;
+    private int? orig_pixel_size = null;
+
     public Gdk.Pixbuf? pixbuf { get; set; }
 
     /**
@@ -53,6 +57,12 @@ public class Granite.Widgets.Avatar : Gtk.EventBox {
      * @param pixel_size to scale the image
      */
     public Avatar.from_file (string filepath, int pixel_size) {
+        load_image (filepath, pixel_size);
+        orig_filename = filepath;
+        orig_pixel_size = pixel_size;
+    }
+
+    private void load_image (string filepath, int pixel_size) {
         try {
             var size = pixel_size * get_style_context ().get_scale ();
             pixbuf = new Gdk.Pixbuf.from_file_at_size (filepath, size, size);
@@ -68,6 +78,7 @@ public class Granite.Widgets.Avatar : Gtk.EventBox {
      */
     public Avatar.with_default_icon (int pixel_size) {
         show_default (pixel_size);
+        orig_pixel_size = pixel_size;
     }
 
     construct {
@@ -78,15 +89,17 @@ public class Granite.Widgets.Avatar : Gtk.EventBox {
         style_context.add_class (Granite.STYLE_CLASS_AVATAR);
 
         notify["pixbuf"].connect (refresh_size_request);
+        Gdk.Screen.get_default ().monitors_changed.connect (dpi_change);
     }
 
     ~Avatar () {
         notify["pixbuf"].disconnect (refresh_size_request);
+        Gdk.Screen.get_default ().monitors_changed.disconnect (dpi_change);
     }
 
     private void refresh_size_request () {
         if (pixbuf != null) {
-            var scale_factor = get_style_context ().get_scale ();
+            var scale_factor = get_scale_factor ();
             set_size_request (pixbuf.width / scale_factor + EXTRA_MARGIN * 2, pixbuf.height / scale_factor + EXTRA_MARGIN * 2);
             draw_theme_background = true;
         } else {
@@ -94,6 +107,16 @@ public class Granite.Widgets.Avatar : Gtk.EventBox {
         }
 
         queue_draw ();
+    }
+
+    private void dpi_change () {
+        if (is_default && orig_pixel_size != null) {
+            show_default (orig_pixel_size);
+        } else {
+            if (orig_filename != null && orig_pixel_size != null) {
+                load_image (orig_filename, orig_pixel_size);
+            }
+        }
     }
 
     /**
@@ -104,12 +127,13 @@ public class Granite.Widgets.Avatar : Gtk.EventBox {
     public void show_default (int pixel_size) {
         Gtk.IconTheme icon_theme = Gtk.IconTheme.get_default ();
         try {
-            pixbuf = icon_theme.load_icon_for_scale (DEFAULT_ICON, pixel_size, get_style_context ().get_scale (), 0);
+            pixbuf = icon_theme.load_icon_for_scale (DEFAULT_ICON, pixel_size, get_scale_factor (), 0);
         } catch (Error e) {
             stderr.printf ("Error setting default avatar icon: %s ", e.message);
         }
 
         draw_theme_background = false;
+        is_default = true;
     }
 
     public override bool draw (Cairo.Context cr) {
@@ -120,7 +144,7 @@ public class Granite.Widgets.Avatar : Gtk.EventBox {
         unowned Gtk.StyleContext style_context = get_style_context ();
         var width = get_allocated_width () - EXTRA_MARGIN * 2;
         var height = get_allocated_height () - EXTRA_MARGIN * 2;
-        var scale_factor = style_context.get_scale ();
+        var scale_factor = get_scale_factor ();
 
         if (draw_theme_background) {
             var border_radius = style_context.get_property (Gtk.STYLE_PROPERTY_BORDER_RADIUS, style_context.get_state ()).get_int ();


### PR DESCRIPTION
I've been doing some investigation into some of the HiDPI issues with the greeter to try and get a better understand of the code and one of the things that stood out to me was the scale of the Avatar widget. While all the other widgets sort of resize themselves when they detect the scaling of the screen, the Avatar doesn't.

This is reproducible by running the granite-demo and adjusting the display's scale factor with the org.gnome.desktop.interface.scale-factor key. All the GTK widgets resize OK, but the Avatar doesn't. This change now reloads the pixbuf and resizes the widget when the DPI of the monitor changes and hence fixes the issue in the Greeter.

The only downside of this is that it won't have any effect on Avatars that have had their pixbuf directly set by the calling code rather than using the `from_file` or `with_default_icon` helpers.