### PR TITLE
Middle clicks close tabs on release instead of press

### DIFF
--- a/lib/Widgets/DynamicNotebook.vala
+++ b/lib/Widgets/DynamicNotebook.vala
@@ -305,13 +305,7 @@ namespace Granite.Widgets {
             });
 
             this.button_press_event.connect ((e) => {
-                e.state &= MODIFIER_MASK;
-
-                if (e.button == 2 && e.state == 0 && close_button_is_visible ()) {
-                    this.closed ();
-                } else if (e.button == 2 && e.state == Gdk.ModifierType.SHIFT_MASK && close_button_is_visible ()) {
-                    this.close_others ();
-                } else if (e.button == 1 && e.type == Gdk.EventType.2BUTTON_PRESS && duplicate_m.visible) {
+                if (e.button == 1 && e.type == Gdk.EventType.2BUTTON_PRESS && duplicate_m.visible) {
                     this.duplicate ();
                 } else if (e.button == 3) {
                     menu.popup (null, null, null, 3, e.time);
@@ -323,6 +317,20 @@ namespace Granite.Widgets {
                     if (this.pinned) {
                         pin_m.label = "Unpin";
                     }
+                } else {
+                    return false;
+                }
+
+                return true;
+            });
+
+            this.button_release_event.connect ((e) => {
+                e.state &= MODIFIER_MASK;
+
+                if (e.button == 2 && e.state == 0 && close_button_is_visible ()) {
+                    this.closed ();
+                } else if (e.button == 2 && e.state == Gdk.ModifierType.SHIFT_MASK && close_button_is_visible ()) {
+                    this.close_others ();
                 } else {
                     return false;
                 }


### PR DESCRIPTION
Changes tab middle click event from `button_press_event` to `button_release_event` to fix #82.