### PR TITLE
Fix handling debug option blocking other options from showing in help

### DIFF
--- a/lib/Application.vala
+++ b/lib/Application.vala
@@ -157,6 +157,8 @@ namespace Granite {
             Granite.Services.Logger.DisplayLevel = Granite.Services.LogLevel.WARN;
 
             Intl.bindtextdomain (exec_name, build_data_dir + "/locale");
+
+            handle_local_options.connect (on_handle_local_options);
         }
 
 #if LINUX
@@ -176,21 +178,15 @@ namespace Granite {
          * @param args array of arguments
          */
         public new int run (string[] args) {
-
-            // parse commandline options
-            var context = new OptionContext ("");
-
-            context.add_main_entries (options, null);
-            context.add_group (Gtk.get_option_group (false));
-            context.set_ignore_unknown_options (true);
-
-            try {
-                context.parse (ref args);
-            } catch { }
-
-            set_options ();
+            add_main_option_entries (options);
 
             return base.run (args);
+        }
+
+        private int on_handle_local_options (VariantDict options) {
+            set_options ();
+
+            return -1;
         }
 
         protected static bool DEBUG = false;


### PR DESCRIPTION
The options were added to an internal `OptionContext` created within `run` and didn't take any other options into account. We now add the options with the native `add_main_option_entries` method in `GLib.Application` so that all the options that get added into the application are parsed correctly. To apply the options we connect to `handle_local_options` signal which is fired after all options were parsed. More info here: https://valadoc.org/gio-2.0/GLib.Application.handle_local_options.html