### PR TITLE
Make settings lookup recursive

### DIFF
--- a/lib/Widgets/Utils.vala
+++ b/lib/Widgets/Utils.vala
@@ -260,9 +260,9 @@ namespace Granite.Widgets.Utils {
         var sss = SettingsSchemaSource.get_default ();
 
         if (sss != null) {
-            if (sss.lookup (PANTHEON_SETTINGS_PATH, false) != null) {
+            if (sss.lookup (PANTHEON_SETTINGS_PATH, true) != null) {
                 return PANTHEON_SETTINGS_PATH;
-            } else if (sss.lookup (WM_SETTINGS_PATH, false) != null) {
+            } else if (sss.lookup (WM_SETTINGS_PATH, true) != null) {
                 return WM_SETTINGS_PATH;
             }
         }


### PR DESCRIPTION
Makes the schema lookup recursive since it wasn't found directly: 
https://valadoc.org/gio-2.0/GLib.SettingsSchemaSource.lookup.html

Fixes gala throwing the following errors when opening the multitasking view:

```
** (gala:27187): WARNING **: Utils.vala:268: No schema indicating the button-layout is installed...
```