### PR TITLE
Fix parsing application options

### DIFF
--- a/lib/Application.vala
+++ b/lib/Application.vala
@@ -178,14 +178,16 @@ namespace Granite {
          * @param args array of arguments
          */
         public new int run (string[] args) {
-            add_main_option_entries (options);
+            var option_group = new OptionGroup ("granite", "Granite Options", _("Show Granite Options"));
+            option_group.add_entries (options);
+
+            add_option_group ((owned)option_group);
 
             return base.run (args);
         }
 
         private int on_handle_local_options (VariantDict options) {
             set_options ();
-
             return -1;
         }
 


### PR DESCRIPTION
Fixes #107.

Instead of adding and overriding main option entries, create a new option group that will be used for showing help for Granite options with `--help-granite`.

The [OptionGroup API](https://valadoc.org/glib-2.0/GLib.OptionGroup.html) suggests to expose an API for getting the OptionGroup by the application but I didn't want to touch the API here, this is only fixing the bug.