### PR TITLE
Update popover calendar when setting date

### DIFF
--- a/lib/Widgets/DatePicker.vala
+++ b/lib/Widgets/DatePicker.vala
@@ -60,6 +60,10 @@ namespace Granite.Widgets {
             set {
                 _date = value;
                 text = _date.format (format);
+                proc_next_day_selected = false;
+                calendar.select_month (value.get_month () - 1, value.get_year ());
+                proc_next_day_selected = false;
+                calendar.select_day (value.get_day_of_month ());
                 date_changed ();
             }
         }


### PR DESCRIPTION
This updates the popover calendar's selected date when the date is set for the DatePicker.

Fixes #112 