### PR TITLE
Add a visible child name property to SettingsSidebar

### DIFF
--- a/lib/Widgets/SettingsSidebar.vala
+++ b/lib/Widgets/SettingsSidebar.vala
@@ -35,9 +35,15 @@ public class Granite.SettingsSidebar : Gtk.ScrolledWindow {
     /**
      * The name of the currently visible Granite.SettingsPage
      */
-    public string visible_child_name {
+    public string? visible_child_name {
         get {
-            return ((SettingsSidebarRow) listbox.get_selected_row ()).name;
+            var selected_row = listbox.get_selected_row ();
+
+            if (selected_row == null) {
+                return null;
+            } else {
+                return ((SettingsSidebarRow) selected_row).name;
+            }
         }
         set {
             foreach (unowned Gtk.Widget listbox_child in listbox.get_children ()) {

--- a/lib/Widgets/SettingsSidebar.vala
+++ b/lib/Widgets/SettingsSidebar.vala
@@ -33,6 +33,22 @@ public class Granite.SettingsSidebar : Gtk.ScrolledWindow {
     public Gtk.Stack stack { get; construct; }
 
     /**
+     * The name of the currently visible Granite.SettingsPage
+     */
+    public string visible_child_name {
+        get {
+            return ((SettingsSidebarRow) listbox.get_selected_row ()).name;
+        }
+        set {
+            foreach (unowned Gtk.Widget listbox_child in listbox.get_children ()) {
+                if (((SettingsSidebarRow) listbox_child).name == value) {
+                    listbox.select_row ((Gtk.ListBoxRow) listbox_child);
+                }
+            }
+        }
+    }
+
+    /**
      * Create a new SettingsSidebar
      */
     public SettingsSidebar (Gtk.Stack stack) {


### PR DESCRIPTION
This unbreaks search in Switchboard. Setting the visible child in the stack seems to get overridden by what is selected in the sidebar. This allows us to set the selected child in the sidebar and thus the visible child in the stack