### PR TITLE
Add code examples

### DIFF
--- a/lib/Widgets/AlertView.vala
+++ b/lib/Widgets/AlertView.vala
@@ -25,6 +25,22 @@
  * It can be used to show an empty view or hiding a panel when this one is disabled.
  *
  * {{../../doc/images/AlertView.png}}
+ *
+ * ''Example''<<BR>>
+ * {{{
+ * public class AlertViewView : Gtk.Grid {
+ *     construct {
+ *         var alert = new Granite.Widgets.AlertView ("Nothing here", "Maybe you can enable <b>something</b> to hide it but <i>otherwise</i> it will stay here", "dialog-warning");
+ *         alert.show_action ("Hide this button");
+ *
+ *         alert.action_activated.connect (() => {
+ *             alert.hide_action ();
+ *         });
+ *
+ *         add (alert);
+ *     }
+ * }
+ * }}}
  */
 public class Granite.Widgets.AlertView : Gtk.Grid {
     public signal void action_activated ();

--- a/lib/Widgets/Avatar.vala
+++ b/lib/Widgets/Avatar.vala
@@ -22,6 +22,25 @@
 /**
  * The Avatar widget allowes to theme & crop images with css BORDER_RADIUS property in the .avatar class.
  *
+ * ''Example''<<BR>>
+ * {{{
+ * public class AvatarView : Gtk.Grid {
+ *     construct {
+ *         var username = GLib.Environment.get_user_name ();
+ *         var iconfile = @"/var/lib/AccountsService/icons/$username";
+ *
+ *         var avatar_dialog = new Granite.Widgets.Avatar.from_file (iconfile, 48);
+ *
+ *         var avatar_default_dialog = new Granite.Widgets.Avatar.with_default_icon (48);
+ *
+ *         row_spacing = 6;
+ *         halign = Gtk.Align.CENTER;
+ *         valign = Gtk.Align.CENTER;
+ *         attach (avatar_dialog, 0, 0, 1, 1);
+ *         attach (avatar_default_dialog, 0, 1, 1, 1);
+ *     }
+ * }
+ * }}}
  */
 public class Granite.Widgets.Avatar : Gtk.EventBox {
     private const string DEFAULT_ICON = "avatar-default";

--- a/lib/Widgets/OverlayBar.vala
+++ b/lib/Widgets/OverlayBar.vala
@@ -38,6 +38,29 @@
  * but you have to be careful not to unset the event for the {@link Gtk.Overlay} at a later stage.
  *
  * @see Gtk.Overlay
+ *
+ * ''Example''<<BR>>
+ * {{{
+ * public class OverlayBarView : Gtk.Overlay {
+ *     construct {
+ *         var button = new Gtk.ToggleButton.with_label ("Show Spinner");
+ * 
+ *         var grid = new Gtk.Grid ();
+ *         grid.halign = Gtk.Align.CENTER;
+ *         grid.valign = Gtk.Align.CENTER;
+ *         grid.add (button);
+ * 
+ *         var overlaybar = new Granite.Widgets.OverlayBar (this);
+ *         overlaybar.label = "Hover the OverlayBar to change its position";
+ *         
+ *         add (grid);
+ * 
+ *         button.toggled.connect (() => {
+ *             overlaybar.active = button.active;
+ *         });
+ *     }
+ * }
+ * }}}
  */
 public class Granite.Widgets.OverlayBar : Gtk.EventBox {
 

--- a/lib/Widgets/SeekBar.vala
+++ b/lib/Widgets/SeekBar.vala
@@ -22,6 +22,108 @@
  * Granite.SeekBar will get the style class .seek-bar
  *
  * {{../../doc/images/SeekBar.png}}
+ *
+ * ''Example''<<BR>>
+ * {{{
+ * public class SeekBarView : Gtk.Grid {
+ *     private Gtk.Popover preview_popover;
+ *     private Gtk.Label preview_label;
+ *
+ *     public SeekBarView () {
+ *         Object (valign: Gtk.Align.CENTER,
+ *                 margin: 24);
+ *     }
+ *
+ *     construct {
+ *         preview_popover = new Gtk.Popover (this);
+ *         preview_popover.can_focus = false;
+ *         preview_popover.sensitive = false;
+ *         preview_popover.modal = false;
+ *         preview_popover.valign = Gtk.Align.CENTER;
+ *
+ *         preview_label = new Gtk.Label ("");
+ *         preview_label.margin = 5;
+ *         preview_popover.add (preview_label);
+ *         preview_popover.show_all ();
+ *         preview_popover.set_visible (false);
+ *
+ *         var seek_bar = new Granite.SeekBar (100);
+ *
+ *         preview_popover.relative_to = seek_bar.scale;
+ *
+ *         seek_bar.scale.motion_notify_event.connect ((event) => {
+ *             update_pointing ((int) event.x);
+ *             if (!seek_bar.is_grabbing) {
+ *                 var duration_decimal = (event.x / ((double) event.window.get_width ()));
+ *                 var duration_mins = Granite.DateTime.seconds_to_time ((int) (duration_decimal * seek_bar.playback_duration));
+ *                 preview_label.label = duration_mins.to_string ();
+ *             }
+ *             return false;
+ *         });
+ *
+ *         seek_bar.scale.enter_notify_event.connect (() => {
+ *             preview_popover.set_visible (true);
+ *             return false;
+ *         });
+ *
+ *         seek_bar.scale.leave_notify_event.connect (() => {
+ *             preview_popover.set_visible (false);
+ *             return false;
+ *         });
+ *
+ *         seek_bar.scale.button_press_event.connect (() => {
+ *             preview_label.margin = 10;
+ *             return false;
+ *         });
+ *
+ *         seek_bar.scale.button_release_event.connect (() => {
+ *             preview_label.margin = 5;
+ *             return false;
+ *         });
+ *
+ *         seek_bar.scale.change_value.connect ((scroll, new_value) => {
+ *             if (new_value >= 0.0 && new_value <= 1.0) {
+ *                 var duration_mins = Granite.DateTime.seconds_to_time ((int) (new_value * seek_bar.playback_duration));
+ *                 preview_label.label = duration_mins.to_string ();
+ *             }
+ *             return false;
+ *         });
+ *
+ *         add (seek_bar);
+ *
+ *         int progress = 0;
+ *         Timeout.add (500, () => {
+ *             if (seek_bar.is_grabbing) {
+ *                 return true;
+ *             }
+ *
+ *             if (progress >= 10) {
+ *                 progress = 0;
+ *                 seek_bar.playback_progress = 0.0;
+ *             } else {
+ *                 progress += 1;
+ *                 seek_bar.playback_progress = progress / 10.0;
+ *             }
+ *             return true;
+ *         });
+ *     }
+ *
+ *     private void update_pointing (int x) {
+ *         var pointing = preview_popover.pointing_to;
+ *         pointing.x = x;
+ *
+ *         // changing the width properly updates arrow position when popover hits the edge
+ *         if (pointing.width == 0) {
+ *             pointing.width = 2;
+ *             pointing.x -= 1;
+ *         } else {
+ *             pointing.width = 0;
+ *         }
+ *
+ *         preview_popover.set_pointing_to (pointing);
+ *     }
+ * }
+ * }}}
  */
 
 public class Granite.SeekBar : Gtk.Grid {

--- a/lib/Widgets/StorageBar.vala
+++ b/lib/Widgets/StorageBar.vala
@@ -23,6 +23,32 @@
  * An horizontal bar showing the remaining amount of space.
  *
  * {{../../doc/images/StorageBar.png}}
+ *
+ * ''Example''<<BR>>
+ * {{{
+ * public class StorageView : Gtk.Grid {
+ *     construct {
+ *         var file_root = GLib.File.new_for_path ("/");
+ *
+ *         try {
+ *             var info = file_root.query_filesystem_info (GLib.FileAttribute.FILESYSTEM_SIZE, null);
+ *
+ *             var size = info.get_attribute_uint64 (GLib.FileAttribute.FILESYSTEM_SIZE);
+ *
+ *             var storage = new Granite.Widgets.StorageBar.with_total_usage (size, size/2);
+ *             storage.update_block_size (Granite.Widgets.StorageBar.ItemDescription.AUDIO, size/40);
+ *             storage.update_block_size (Granite.Widgets.StorageBar.ItemDescription.VIDEO, size/30);
+ *             storage.update_block_size (Granite.Widgets.StorageBar.ItemDescription.APP, size/20);
+ *             storage.update_block_size (Granite.Widgets.StorageBar.ItemDescription.PHOTO, size/10);
+ *             storage.update_block_size (Granite.Widgets.StorageBar.ItemDescription.FILES, size/5);
+ *
+ *             add (storage);
+ *         } catch (Error e) {
+ *             critical (e.message);
+ *         }
+ *     }
+ * }
+ * }}}
  */
 public class Granite.Widgets.StorageBar : Gtk.Box {
     public enum ItemDescription {

--- a/lib/Widgets/Welcome.vala
+++ b/lib/Widgets/Welcome.vala
@@ -27,7 +27,8 @@
  * Granite.Widgets.Welcome will get the style class `welcome`.
  *
  * {{../../doc/images/Welcome.png}}
- * 
+ *
+ * ''Example''<<BR>>
  * {{{
  * public class WelcomeView : Gtk.Grid {
  *     construct {


### PR DESCRIPTION
This adds code examples (from granite demo) for several widgets:

* Alertview
* Avatar
* OverlayBar
* SeekBar
* StorageBar
* Add an "example" label to Welcome view to be consistent