### PR TITLE
Prevent ModeButton deselection (for #67)

### DIFF
--- a/demo/Views/ModeButtonView.vala
+++ b/demo/Views/ModeButtonView.vala
@@ -30,7 +30,6 @@ public class ModeButtonView : Gtk.Grid {
         icon_mode.append_icon ("view-grid-symbolic", Gtk.IconSize.BUTTON);
         icon_mode.append_icon ("view-list-symbolic", Gtk.IconSize.BUTTON);
         icon_mode.append_icon ("view-column-symbolic", Gtk.IconSize.BUTTON);
-        icon_mode.can_deselect = false;
 
         var text_mode = new Granite.Widgets.ModeButton ();
         text_mode.append_text ("Foo");

--- a/demo/Views/ModeButtonView.vala
+++ b/demo/Views/ModeButtonView.vala
@@ -30,6 +30,7 @@ public class ModeButtonView : Gtk.Grid {
         icon_mode.append_icon ("view-grid-symbolic", Gtk.IconSize.BUTTON);
         icon_mode.append_icon ("view-list-symbolic", Gtk.IconSize.BUTTON);
         icon_mode.append_icon ("view-column-symbolic", Gtk.IconSize.BUTTON);
+        icon_mode.can_deselect = false;
 
         var text_mode = new Granite.Widgets.ModeButton ();
         text_mode.append_text ("Foo");

--- a/lib/Widgets/ModeButton.vala
+++ b/lib/Widgets/ModeButton.vala
@@ -64,7 +64,7 @@ namespace Granite.Widgets {
          * Makes new ModeButton
          */
         public ModeButton () {
-            
+
         }
 
         construct {
@@ -155,8 +155,9 @@ namespace Granite.Widgets {
             _selected = -1;
 
             foreach (var item in item_map.values) {
-                if (item != null && item.active)
+                if (item != null && item.active) {
                     item.set_active (false);
+                }
             }
         }
 
@@ -178,8 +179,9 @@ namespace Granite.Widgets {
                 assert (new_item.index == new_active_index);
                 new_item.set_active (true);
 
-                if (_selected == new_active_index)
+                if (_selected == new_active_index) {
                     return;
+                }
 
                 // Unselect the previous item
                 var old_item = item_map[_selected] as Item;
@@ -189,8 +191,9 @@ namespace Granite.Widgets {
                 // the user.
                 _selected = new_active_index;
 
-                if (old_item != null)
+                if (old_item != null) {
                     old_item.set_active (false);
+                }
 
                 mode_changed (new_item.get_child ());
             }
@@ -236,8 +239,9 @@ namespace Granite.Widgets {
         public void clear_children () {
             foreach (weak Gtk.Widget button in get_children ()) {
                 button.hide ();
-                if (button.get_parent () != null)
+                if (button.get_parent () != null) {
                     base.remove (button);
+                }
             }
 
             item_map.clear ();
@@ -268,12 +272,14 @@ namespace Granite.Widgets {
             uint n_children = children.length ();
 
             var selected_item = item_map[selected];
-            if (selected_item == null)
+            if (selected_item == null) {
                 return false;
+            }
 
             int new_item = children.index (selected_item);
-            if (new_item < 0)
+            if (new_item < 0) {
                 return false;
+            }
 
             do {
                 new_item += offset;

--- a/lib/Widgets/ModeButton.vala
+++ b/lib/Widgets/ModeButton.vala
@@ -49,13 +49,6 @@ namespace Granite.Widgets {
             get { return _selected; }
             set { set_active (value); }
         }
-        
-        /**
-         * Controls whether the user can deselect an item by clicking it again.
-         * This property does not prevent programmatic deselection of the
-         * current item.
-         */
-        public bool can_deselect { get; set; default = true; }
 
         /**
          * Read-only length of current ModeButton
@@ -134,7 +127,7 @@ namespace Granite.Widgets {
             item.toggled.connect (() => {
                 if (item.active) {
                     selected = item.index;
-                } else if (selected == item.index && !can_deselect) {
+                } else if (selected == item.index) {
                     // If the selected index still references this item, then it
                     // was toggled by the user, not programmatically.
                     // -> Reactivate the item to prevent an empty selection.


### PR DESCRIPTION
This is my attempt at fixing the cosmetic glitch in #67 without breaking backward compatibility. However:

* I'm not sure if `can_deselect` is the best name for this property within the larger Gtk universe.
* I'm also not sure if deselection is a supported feature of the ModeButton right now. The `selected` property is not updated to -1 when it happens and it can't be observed using the `mode_changed` signal, and "fixing" that could break apps which don't expect deselection to happen.
  If no app relies on the current deselection behavior, it might be better to *always* prevent deselection instead of making it configurable. That would also fix affected apps without changing their code.
* The code I've added relies very much on the order of execution to distinguish user events from programmatic deselection. It's probably a bit too "clever" :/

Feedback welcome, I'll be happy to iterate on this.