### PR TITLE
DynamicNotebook: make the keybinding trigger the right signal

### DIFF
--- a/lib/Widgets/DynamicNotebook.vala
+++ b/lib/Widgets/DynamicNotebook.vala
@@ -873,8 +873,11 @@ namespace Granite.Widgets {
                     case Gdk.Key.@w:
                     case Gdk.Key.@W:
                         if (e.state == Gdk.ModifierType.CONTROL_MASK) {
-                            if (!tabs_closable) break;
-                            remove_tab (current);
+                            if (!tabs_closable) {
+                                break;
+                            }
+
+                            current.close ();
                             return true;
                         }
 


### PR DESCRIPTION
Because of this, the restore features were not always working with `Ctrl` + `w` (especially with Code)