### PR TITLE
Deprecate Granite.Application

### DIFF
--- a/lib/Application.vala
+++ b/lib/Application.vala
@@ -22,6 +22,7 @@ namespace Granite {
      * This is the base class for all Granite-based apps. It has methods that help
      * to create a great deal of an app's functionality.
      */
+    [Version (deprecated = true, deprecated_since = "0.5.0", replacement = "Gtk.Application")]
     public abstract class Application : Gtk.Application {
 
         public string build_data_dir;


### PR DESCRIPTION
Officially deprecate Granite.Application

I think the only thing we were holding onto here is the --debug flag which we agreed is already covered by `--gtk-debug`