### PR TITLE
DateTime: Add commas in date format

### DIFF
--- a/lib/DateTime.vala
+++ b/lib/DateTime.vala
@@ -145,7 +145,7 @@ namespace Granite.DateTime {
     public static string get_default_date_format (bool with_weekday = false, bool with_day = true, bool with_year = false) {
         if (with_weekday == true && with_day == true && with_year == true) {
             /// TRANSLATORS: a GLib.DateTime format showing the weekday, date, and year
-            return _("%a %b %e %Y");
+            return _("%a, %b %e, %Y");
         } else if (with_weekday == false && with_day == true && with_year == true) {
             /// TRANSLATORS: a GLib.DateTime format showing the date and year
             return _("%b %e %Y");
@@ -163,7 +163,7 @@ namespace Granite.DateTime {
             return _("%a");
         } else if (with_weekday == true && with_day == true && with_year == false) {
             /// TRANSLATORS: a GLib.DateTime format showing the weekday and date
-            return _("%a %b %e");
+            return _("%a, %b %e");
         } else if (with_weekday == false && with_day == false && with_year == false) {
             /// TRANSLATORS: a GLib.DateTime format showing the month.
             return _("%b");


### PR DESCRIPTION
The date format in US English should include commas such as "Thu, Aug 2, 2018" and "Thu, Aug 2"