### PR TITLE
Change settings to look at a more relevant value for time format

### DIFF
--- a/lib/DateTime.vala
+++ b/lib/DateTime.vala
@@ -110,7 +110,7 @@ namespace Granite.DateTime {
      * @return true if the clock format is 12h based, false otherwise.
      */
     private static bool is_clock_format_12h () {
-        var h24_settings = new Settings ("org.gnome.desktop.interface");
+        var h24_settings = new Settings ("io.elementary.desktop.wingpanel.datetime");
         var format = h24_settings.get_string ("clock-format");
         return (format.contains ("12h"));
     }


### PR DESCRIPTION
This particular PR will fix elementary/calendar#268 and fix elementary/calendar#91.

This will only fix those issues for Calendar in elementary, but it will probably break things in other systems that don't have the wingpanel indicator, or a way to change the format of the wingpanel indicator.

Either way, it seems reasonable to expect Granite to respect the system setting for elementary over anything else.