### PR TITLE
 Add utilities for marking up accel tooltips

### DIFF
--- a/demo/CMakeLists.txt
+++ b/demo/CMakeLists.txt
@@ -23,6 +23,7 @@ vala_precompile (VALA_C ${EXEC_NAME}
     Views/SourceListView.vala
     Views/StorageView.vala
     Views/ToastView.vala
+    Views/UtilsView.vala
     Views/WelcomeView.vala
     Views/AsyncImageView.vala
     Views/SettingsView/SettingsView.vala

--- a/demo/GraniteDemo.vala
+++ b/demo/GraniteDemo.vala
@@ -45,6 +45,7 @@ public class Granite.Demo : Gtk.Application {
         var source_list_view = new SourceListView ();
         var storage_view = new StorageView ();
         var toast_view = new ToastView ();
+        var utils_view = new UtilsView ();
         var welcome = new WelcomeView ();
         var message_dialog_view = new MessageDialogView (window);
         var async_image_view = new AsyncImageView ();
@@ -63,6 +64,7 @@ public class Granite.Demo : Gtk.Application {
         main_stack.add_titled (source_list_view, "sourcelist", "SourceList");
         main_stack.add_titled (storage_view, "storage", "StorageBar");
         main_stack.add_titled (toast_view, "toasts", "Toast");
+        main_stack.add_titled (utils_view, "utils", "Utils");
         main_stack.add_titled (message_dialog_view, "message", "MessageDialog");
         main_stack.add_titled (async_image_view, "asyncimage", "AsyncImage");
 

--- a/demo/Views/UtilsView.vala
+++ b/demo/Views/UtilsView.vala
@@ -1,0 +1,37 @@
+/*
+* Copyright (c) 2018 elementary, Inc. (https://elementary.io)
+*
+* This library is free software; you can redistribute it and/or
+* modify it under the terms of the GNU Lesser General Public
+* License as published by the Free Software Foundation; either
+* version 3 of the License, or (at your option) any later version.
+*
+* This library is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with this library; if not, write to the
+* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+* Boston, MA 02110-1301 USA.
+*/
+
+public class UtilsView : Gtk.Grid {
+    construct {
+        var tooltip_markup_label = new Gtk.Label ("Markup Accel Tooltips:");
+        tooltip_markup_label.halign = Gtk.Align.END;
+
+        var button_one = new Gtk.Button.from_icon_name ("mail-reply-all", Gtk.IconSize.LARGE_TOOLBAR);
+        button_one.tooltip_markup = markup_accel_tooltip ("Reply All", {"<Ctrl><Shift>R"});
+
+        var button_two = new Gtk.Button.from_icon_name ("color-fill", Gtk.IconSize.LARGE_TOOLBAR);
+        button_two.tooltip_markup = markup_accel_tooltip ("Spill color bucket", {"<Super>R", "<Ctrl><Shift>Up"});
+
+        halign = valign = Gtk.Align.CENTER;
+        column_spacing = 12;
+        add (tooltip_markup_label);
+        add (button_one);
+        add (button_two);
+    }
+}

--- a/demo/Views/UtilsView.vala
+++ b/demo/Views/UtilsView.vala
@@ -23,10 +23,10 @@ public class UtilsView : Gtk.Grid {
         tooltip_markup_label.halign = Gtk.Align.END;
 
         var button_one = new Gtk.Button.from_icon_name ("mail-reply-all", Gtk.IconSize.LARGE_TOOLBAR);
-        button_one.tooltip_markup = Granite.markup_accel_tooltip ("Reply All", {"<Ctrl><Shift>R"});
+        button_one.tooltip_markup = Granite.markup_accel_tooltip ({"<Ctrl><Shift>R"}, "Reply All");
 
-        var button_two = new Gtk.Button.from_icon_name ("color-fill", Gtk.IconSize.LARGE_TOOLBAR);
-        button_two.tooltip_markup = Granite.markup_accel_tooltip ("Spill color bucket", {"<Super>R", "<Ctrl><Shift>Up"});
+        var button_two = new Gtk.Button.with_label ("Label Buttons");
+        button_two.tooltip_markup = Granite.markup_accel_tooltip ({"<Super>R", "<Ctrl><Shift>Up"});
 
         halign = valign = Gtk.Align.CENTER;
         column_spacing = 12;

--- a/demo/Views/UtilsView.vala
+++ b/demo/Views/UtilsView.vala
@@ -23,10 +23,10 @@ public class UtilsView : Gtk.Grid {
         tooltip_markup_label.halign = Gtk.Align.END;
 
         var button_one = new Gtk.Button.from_icon_name ("mail-reply-all", Gtk.IconSize.LARGE_TOOLBAR);
-        button_one.tooltip_markup = markup_accel_tooltip ("Reply All", {"<Ctrl><Shift>R"});
+        button_one.tooltip_markup = Granite.markup_accel_tooltip ("Reply All", {"<Ctrl><Shift>R"});
 
         var button_two = new Gtk.Button.from_icon_name ("color-fill", Gtk.IconSize.LARGE_TOOLBAR);
-        button_two.tooltip_markup = markup_accel_tooltip ("Spill color bucket", {"<Super>R", "<Ctrl><Shift>Up"});
+        button_two.tooltip_markup = Granite.markup_accel_tooltip ("Spill color bucket", {"<Super>R", "<Ctrl><Shift>Up"});
 
         halign = valign = Gtk.Align.CENTER;
         column_spacing = 12;

--- a/lib/Widgets/Utils.vala
+++ b/lib/Widgets/Utils.vala
@@ -83,7 +83,7 @@ public enum Granite.CloseButtonPosition
  *
  * @return a human-readable string like "Ctrl + A" or "⌘ + →"
  */
-public string accel_to_string (string accel) {
+public static string accel_to_string (string accel) {
     uint accel_key;
     Gdk.ModifierType accel_mods;
     Gtk.accelerator_parse (accel, out accel_key, out accel_mods);
@@ -135,7 +135,7 @@ public string accel_to_string (string accel) {
  *
  * @return {@link Pango} markup with the description label on one line and a list of human-readable accels on a new line
  */
-public string markup_accel_tooltip (string description, string[] accels) {
+public static string markup_accel_tooltip (string description, string[] accels) {
     int i = 0;
     foreach (string accel in accels) {
         accels[i] = accel_to_string (accel);

--- a/lib/Widgets/Utils.vala
+++ b/lib/Widgets/Utils.vala
@@ -129,7 +129,12 @@ public static string accel_to_string (string accel) {
 }
 
 /**
- * Takes a description and an array of accels and returns {@link Pango} markup for use in a {@link Gtk.Tooltip}
+ * Takes a description and an array of accels and returns {@link Pango} markup for use in a {@link Gtk.Tooltip}. This method uses {@link Granite.accel_to_string}.
+ *
+ * Example:
+ *
+ * Description
+ * Shortcut 1, Shortcut 2
  *
  * @param a string array of accelerator labels like {"<Control>a", "<Super>Right"}
  *
@@ -138,10 +143,8 @@ public static string accel_to_string (string accel) {
  * @return {@link Pango} markup with the description label on one line and a list of human-readable accels on a new line
  */
 public static string markup_accel_tooltip (string[] accels, string? description = null) {
-    int i = 0;
-    foreach (string accel in accels) {
-        accels[i] = accel_to_string (accel);
-        i++;
+    for (int i = 0; i < accels.length; i++) {
+       accels[i] = accel_to_string (accels[i]); 
     }
 
     ///TRANSLATORS: This is a delimiter that separates two keyboard shortcut labels like "⌘ + →, Control + A"

--- a/lib/Widgets/Utils.vala
+++ b/lib/Widgets/Utils.vala
@@ -83,7 +83,7 @@ public enum Granite.CloseButtonPosition
  *
  * @return a human-readable string like "Ctrl + A" or "⌘ + →"
  */
-public string[] accel_to_string (string accel) {
+public string accel_to_string (string accel) {
     uint accel_key;
     Gdk.ModifierType accel_mods;
     Gtk.accelerator_parse (accel, out accel_key, out accel_mods);
@@ -121,9 +121,9 @@ public string[] accel_to_string (string accel) {
         default:
             arr += Gtk.accelerator_get_label (accel_key, 0);
             break;
-     }
+    }
 
-    return arr;
+    return string.joinv (" + ", arr);
 }
 
 /**
@@ -138,8 +138,7 @@ public string[] accel_to_string (string accel) {
 public string markup_accel_tooltip (string description, string[] accels) {
     int i = 0;
     foreach (string accel in accels) {
-        string[] keys = accel_to_string (accel);
-        accels[i] = string.joinv (" + ", keys);
+        accels[i] = accel_to_string (accel);
         i++;
     }
 

--- a/lib/Widgets/Utils.vala
+++ b/lib/Widgets/Utils.vala
@@ -131,13 +131,13 @@ public static string accel_to_string (string accel) {
 /**
  * Takes a description and an array of accels and returns {@link Pango} markup for use in a {@link Gtk.Tooltip}
  *
- * @param description a standard tooltip text string
- *
  * @param a string array of accelerator labels like {"<Control>a", "<Super>Right"}
+ *
+ * @param description a standard tooltip text string
  *
  * @return {@link Pango} markup with the description label on one line and a list of human-readable accels on a new line
  */
-public static string markup_accel_tooltip (string description, string[] accels) {
+public static string markup_accel_tooltip (string[] accels, string? description = null) {
     int i = 0;
     foreach (string accel in accels) {
         accels[i] = accel_to_string (accel);
@@ -147,7 +147,13 @@ public static string markup_accel_tooltip (string description, string[] accels) 
     ///TRANSLATORS: This is a delimiter that separates two keyboard shortcut labels like "⌘ + →, Control + A"
     var accel_label = string.joinv (_(", "), accels);
 
-    return "%s\n<span weight=\"600\" size=\"smaller\" alpha=\"75%\">%s</span>".printf (description, accel_label);
+    var markup = """<span weight="600" size="smaller" alpha="75%">%s</span>""".printf (accel_label);
+
+    if (description != null && description != "") {
+        markup = string.join ("\n", description, markup);
+    }
+
+    return markup;
 }
 
 }

--- a/lib/Widgets/Utils.vala
+++ b/lib/Widgets/Utils.vala
@@ -79,7 +79,7 @@ public enum Granite.CloseButtonPosition
 /**
  * Converts a {@link Gtk.accelerator_parse} style accel string to a human-readable string.
  *
- * @param accel an accelerator label like “<Control>a” or “<Super_L>Right”
+ * @param accel an accelerator label like “<Control>a” or “<Super>Right”
  *
  * @return a human-readable string like "Ctrl + A" or "⌘ + →"
  */
@@ -129,16 +129,16 @@ public string[] accel_to_string (string accel) {
 /**
  * Takes a description and an array of accels and returns {@link Pango} markup for use in a {@link Gtk.Tooltip}
  *
- * @param description
+ * @param description a standard tooltip text string
  *
- * @param an array of accelerator labels like {"<Control>a", "<Super_L>Right"}
+ * @param a string array of accelerator labels like {"<Control>a", "<Super>Right"}
  *
  * @return {@link Pango} markup with the description label on one line and a list of human-readable accels on a new line
  */
 public string markup_accel_tooltip (string description, string[] accels) {
     int i = 0;
     foreach (string accel in accels) {
-        string[] keys = parse_accelerator (accel);
+        string[] keys = accel_to_string (accel);
         accels[i] = string.joinv (" + ", keys);
         i++;
     }

--- a/lib/Widgets/Utils.vala
+++ b/lib/Widgets/Utils.vala
@@ -142,7 +142,8 @@ public string markup_accel_tooltip (string description, string[] accels) {
         i++;
     }
 
-    var accel_label = string.joinv (", ", accels);
+    ///TRANSLATORS: This is a delimiter that separates two keyboard shortcut labels like "⌘ + →, Control + A"
+    var accel_label = string.joinv (_(", "), accels);
 
     return "%s\n<span weight=\"600\" size=\"smaller\" alpha=\"75%\">%s</span>".printf (description, accel_label);
 }

--- a/lib/Widgets/Utils.vala
+++ b/lib/Widgets/Utils.vala
@@ -76,6 +76,8 @@ public enum Granite.CloseButtonPosition
     RIGHT
 }
 
+namespace Granite {
+
 /**
  * Converts a {@link Gtk.accelerator_parse} style accel string to a human-readable string.
  *
@@ -146,6 +148,8 @@ public static string markup_accel_tooltip (string description, string[] accels) 
     var accel_label = string.joinv (_(", "), accels);
 
     return "%s\n<span weight=\"600\" size=\"smaller\" alpha=\"75%\">%s</span>".printf (description, accel_label);
+}
+
 }
 
 /**

--- a/lib/Widgets/Utils.vala
+++ b/lib/Widgets/Utils.vala
@@ -77,6 +77,78 @@ public enum Granite.CloseButtonPosition
 }
 
 /**
+ * Converts a {@link Gtk.accelerator_parse} style accel string to a human-readable string.
+ *
+ * @param accel an accelerator label like “<Control>a” or “<Super_L>Right”
+ *
+ * @return a human-readable string like "Ctrl + A" or "⌘ + →"
+ */
+public string[] accel_to_string (string accel) {
+    uint accel_key;
+    Gdk.ModifierType accel_mods;
+    Gtk.accelerator_parse (accel, out accel_key, out accel_mods);
+
+    string[] arr = {};
+    if (Gdk.ModifierType.SUPER_MASK in accel_mods) {
+        arr += "⌘";
+    }
+
+    if (Gdk.ModifierType.SHIFT_MASK in accel_mods) {
+        arr += _("Shift");
+    }
+
+    if (Gdk.ModifierType.CONTROL_MASK in accel_mods) {
+        arr += _("Ctrl");
+    }
+
+    if (Gdk.ModifierType.MOD1_MASK in accel_mods) {
+        arr += _("Alt");
+    }
+
+    switch (accel_key) {
+        case Gdk.Key.Up:
+            arr += "↑";
+            break;
+        case Gdk.Key.Down:
+            arr += "↓";
+            break;
+        case Gdk.Key.Left:
+            arr += "←";
+            break;
+        case Gdk.Key.Right:
+            arr += "→";
+            break;
+        default:
+            arr += Gtk.accelerator_get_label (accel_key, 0);
+            break;
+     }
+
+    return arr;
+}
+
+/**
+ * Takes a description and an array of accels and returns {@link Pango} markup for use in a {@link Gtk.Tooltip}
+ *
+ * @param description
+ *
+ * @param an array of accelerator labels like {"<Control>a", "<Super_L>Right"}
+ *
+ * @return {@link Pango} markup with the description label on one line and a list of human-readable accels on a new line
+ */
+public string markup_accel_tooltip (string description, string[] accels) {
+    int i = 0;
+    foreach (string accel in accels) {
+        string[] keys = parse_accelerator (accel);
+        accels[i] = string.joinv (" + ", keys);
+        i++;
+    }
+
+    var accel_label = string.joinv (", ", accels);
+
+    return "%s\n<span weight=\"600\" size=\"smaller\" alpha=\"75%\">%s</span>".printf (description, accel_label);
+}
+
+/**
  * This namespace contains functions to apply CSS stylesheets to widgets.
  */
 namespace Granite.Widgets.Utils {


### PR DESCRIPTION
Fixes #228 

Adds two new utils:
* `accel_to_string`, which takes something like `"<Super>Right"` and returns `"⌘ + →"`
* `markup_accel_tooltip`, which takes a description and an accel string array and returns the markup pictured below for tooltips

![screenshot from 2018-10-23 11 07 26 2x](https://user-images.githubusercontent.com/7277719/47381085-e8eaeb80-d6b3-11e8-8063-a957d69f44bd.png)