### PR TITLE
Allow description to be null

### DIFF
--- a/demo/Views/UtilsView.vala
+++ b/demo/Views/UtilsView.vala
@@ -23,10 +23,10 @@ public class UtilsView : Gtk.Grid {
         tooltip_markup_label.halign = Gtk.Align.END;
 
         var button_one = new Gtk.Button.from_icon_name ("mail-reply-all", Gtk.IconSize.LARGE_TOOLBAR);
-        button_one.tooltip_markup = Granite.markup_accel_tooltip ("Reply All", {"<Ctrl><Shift>R"});
+        button_one.tooltip_markup = Granite.markup_accel_tooltip ({"<Ctrl><Shift>R"}, "Reply All");
 
-        var button_two = new Gtk.Button.from_icon_name ("color-fill", Gtk.IconSize.LARGE_TOOLBAR);
-        button_two.tooltip_markup = Granite.markup_accel_tooltip ("Spill color bucket", {"<Super>R", "<Ctrl><Shift>Up"});
+        var button_two = new Gtk.Button.with_label ("Label Buttons");
+        button_two.tooltip_markup = Granite.markup_accel_tooltip ({"<Super>R", "<Ctrl><Shift>Up"});
 
         halign = valign = Gtk.Align.CENTER;
         column_spacing = 12;

--- a/lib/Widgets/Utils.vala
+++ b/lib/Widgets/Utils.vala
@@ -147,7 +147,7 @@ public static string markup_accel_tooltip (string[] accels, string? description 
     ///TRANSLATORS: This is a delimiter that separates two keyboard shortcut labels like "⌘ + →, Control + A"
     var accel_label = string.joinv (_(", "), accels);
 
-    var markup = "<span weight=\"600\" size=\"smaller\" alpha=\"75%\">%s</span>".printf (accel_label);
+    var markup = """<span weight="600" size="smaller" alpha="75%">%s</span>""".printf (accel_label);
 
     if (description != null && description != "") {
         markup = string.join ("\n", description, markup);

--- a/lib/Widgets/Utils.vala
+++ b/lib/Widgets/Utils.vala
@@ -147,11 +147,13 @@ public static string markup_accel_tooltip (string[] accels, string? description 
     ///TRANSLATORS: This is a delimiter that separates two keyboard shortcut labels like "⌘ + →, Control + A"
     var accel_label = string.joinv (_(", "), accels);
 
+    var markup = "<span weight=\"600\" size=\"smaller\" alpha=\"75%\">%s</span>".printf (accel_label);
+
     if (description != null && description != "") {
-        return "%s\n<span weight=\"600\" size=\"smaller\" alpha=\"75%\">%s</span>".printf (description, accel_label);
+        return string.join ("\n", description, markup);
     }
 
-    return "<span weight=\"600\" size=\"smaller\" alpha=\"75%\">%s</span>".printf (accel_label);
+    return markup;
 }
 
 }

--- a/lib/Widgets/Utils.vala
+++ b/lib/Widgets/Utils.vala
@@ -131,13 +131,13 @@ public static string accel_to_string (string accel) {
 /**
  * Takes a description and an array of accels and returns {@link Pango} markup for use in a {@link Gtk.Tooltip}
  *
- * @param description a standard tooltip text string
- *
  * @param a string array of accelerator labels like {"<Control>a", "<Super>Right"}
+ *
+ * @param description a standard tooltip text string
  *
  * @return {@link Pango} markup with the description label on one line and a list of human-readable accels on a new line
  */
-public static string markup_accel_tooltip (string description, string[] accels) {
+public static string markup_accel_tooltip (string[] accels, string? description = null) {
     int i = 0;
     foreach (string accel in accels) {
         accels[i] = accel_to_string (accel);
@@ -147,7 +147,11 @@ public static string markup_accel_tooltip (string description, string[] accels) 
     ///TRANSLATORS: This is a delimiter that separates two keyboard shortcut labels like "⌘ + →, Control + A"
     var accel_label = string.joinv (_(", "), accels);
 
-    return "%s\n<span weight=\"600\" size=\"smaller\" alpha=\"75%\">%s</span>".printf (description, accel_label);
+    if (description != null && description != "") {
+        return "%s\n<span weight=\"600\" size=\"smaller\" alpha=\"75%\">%s</span>".printf (description, accel_label);
+    }
+
+    return "<span weight=\"600\" size=\"smaller\" alpha=\"75%\">%s</span>".printf (accel_label);
 }
 
 }

--- a/lib/Widgets/Utils.vala
+++ b/lib/Widgets/Utils.vala
@@ -150,7 +150,7 @@ public static string markup_accel_tooltip (string[] accels, string? description 
     var markup = "<span weight=\"600\" size=\"smaller\" alpha=\"75%\">%s</span>".printf (accel_label);
 
     if (description != null && description != "") {
-        return string.join ("\n", description, markup);
+        markup = string.join ("\n", description, markup);
     }
 
     return markup;


### PR DESCRIPTION
Reverses the order of arguments and allows the description to be null to accommodate text buttons

![screenshot from 2018-10-24 09 16 18 2x](https://user-images.githubusercontent.com/7277719/47445363-98d05f80-d76d-11e8-88ca-d675c8367745.png)