### PR TITLE
Ignore empty accel strings

### DIFF
--- a/lib/Widgets/Utils.vala
+++ b/lib/Widgets/Utils.vala
@@ -157,24 +157,31 @@ public static string markup_accel_tooltip (string[]? accels, string? description
     if (description != null && description != "") {
         parts += description;
     }
+
     if (accels != null &&  accels.length > 0) {
         string[] unique_accels = {};
 
         for (int i = 0; i < accels.length; i++) {
-            var accel_string = accel_to_string (accels[i]);
+            if (accels[i] == "") {
+                continue;
+            }
 
+            var accel_string = accel_to_string (accels[i]);
             if (!(accel_string in unique_accels)) {
                 unique_accels += accel_string;
             }
         }
 
-        ///TRANSLATORS: This is a delimiter that separates two keyboard shortcut labels like "⌘ + →, Control + A"
-        var accel_label = string.joinv (_(", "), unique_accels);
+        if (unique_accels.length > 0) {
+            ///TRANSLATORS: This is a delimiter that separates two keyboard shortcut labels like "⌘ + →, Control + A"
+            var accel_label = string.joinv (_(", "), unique_accels);
 
-        var accel_markup = """<span weight="600" size="smaller" alpha="75%">%s</span>""".printf (accel_label);
+            var accel_markup = """<span weight="600" size="smaller" alpha="75%">%s</span>""".printf (accel_label);
 
-        parts += accel_markup;
+            parts += accel_markup;
+        }
     }
+
     return string.joinv ("\n", parts);
 }
 


### PR DESCRIPTION
While looking into the Applications menu tooltip I noticed that the keybinding settings would return an array with an empty string, causing tooltips to look like:
![screenshot from 2018-12-07 12 36 37](https://user-images.githubusercontent.com/523210/49646814-9b86cb80-fa20-11e8-9d80-da76fdc53983.png)

Example code applications menu that would return array with empty string when keyboard shortcut was set to Disabled.
```
private const string KEYBINDING_SCHEMA = "org.gnome.desktop.wm.keybindings";
var keybinding_settings = new GLib.Settings (KEYBINDING_SCHEMA);
keybinding_settings.get_strv ("panel-main-menu");
```

This PR checks for empty accel strings and ignores them.

I've also implemented this filter in the applications-menu itself: https://github.com/elementary/applications-menu/pull/161