### PR TITLE
Handle 'Return' key

### DIFF
--- a/demo/Views/UtilsView.vala
+++ b/demo/Views/UtilsView.vala
@@ -26,7 +26,7 @@ public class UtilsView : Gtk.Grid {
         button_one.tooltip_markup = Granite.markup_accel_tooltip ({"<Ctrl><Shift>R"}, "Reply All");
 
         var button_two = new Gtk.Button.with_label ("Label Buttons");
-        button_two.tooltip_markup = Granite.markup_accel_tooltip ({"<Super>R", "<Ctrl><Shift>Up"});
+        button_two.tooltip_markup = Granite.markup_accel_tooltip ({"<Super>R", "<Ctrl><Shift>Up", "<Ctrl>Return"});
 
         halign = valign = Gtk.Align.CENTER;
         column_spacing = 12;

--- a/lib/Widgets/Utils.vala
+++ b/lib/Widgets/Utils.vala
@@ -130,7 +130,6 @@ public static string accel_to_string (string accel) {
             ///TRANSLATORS: This is a non-symbol representation of the "+" key
             arr += _("Plus");
             break;
-        case Gdk.Key.KP_Enter:
         case Gdk.Key.Return:
             arr += _("Enter");
             break;

--- a/lib/Widgets/Utils.vala
+++ b/lib/Widgets/Utils.vala
@@ -130,6 +130,10 @@ public static string accel_to_string (string accel) {
             ///TRANSLATORS: This is a non-symbol representation of the "+" key
             arr += _("Plus");
             break;
+        case Gdk.Key.KP_Enter:
+        case Gdk.Key.Return:
+            arr += _("Enter");
+            break;
         default:
             arr += Gtk.accelerator_get_label (accel_key, 0);
             break;


### PR DESCRIPTION
It looks like currently passing "Enter" to `markup_accel_tooltip` results in a blank label, and passing "Return" lists that as the key (even though everywhere else we refer to the key as "Enter". This fixes the latter case.