### PR TITLE
Add function to check if history is enabled within the privacy settings

### DIFF
--- a/lib/Services/System.vala
+++ b/lib/Services/System.vala
@@ -168,11 +168,12 @@ namespace Granite.Services {
         private static GLib.Settings? privacy_settings = null;
 
         /**
-         * Returns whether privacy mode is enabled in the system settings or not.
+         * Returns whether history is enabled within the Security and Privacy system settings or not. A value of true
+         * means that you should store information such as the last opened file or a history within the app.
          *
-         * Checks the "remember_recent_files" key in "org.gnome.desktop.privacy", returning false if the schema does not exist.
+         * Checks the "remember_recent_files" key in "org.gnome.desktop.privacy", returning true if the schema does not exist.
          */
-        public static bool is_privacy_mode_enabled () {
+        public static bool history_is_enabled () {
             if (privacy_settings_schema == null) {
                 privacy_settings_schema = SettingsSchemaSource.get_default ().lookup ("org.gnome.desktop.privacy", true);
             }
@@ -185,7 +186,7 @@ namespace Granite.Services {
                 return privacy_settings.get_boolean ("remember-recent-files");
             }
 
-            return false;
+            return true;
         }
     }
 }

--- a/lib/Services/System.vala
+++ b/lib/Services/System.vala
@@ -163,8 +163,29 @@ namespace Granite.Services {
                 error (e.message);
             }
         }
-        
-    }
-    
-}
 
+        private static GLib.SettingsSchema? privacy_settings_schema = null;
+        private static GLib.Settings? privacy_settings = null;
+
+        /**
+         * Returns whether privacy mode is enabled in the system settings or not.
+         *
+         * Checks the "remember_recent_files" key in "org.gnome.desktop.privacy", returning false if the schema does not exist.
+         */
+        public static bool is_privacy_mode_enabled () {
+            if (privacy_settings_schema == null) {
+                privacy_settings_schema = SettingsSchemaSource.get_default ().lookup ("org.gnome.desktop.privacy", true);
+            }
+
+            if (privacy_settings_schema != null && privacy_settings_schema.has_key ("remember-recent-files")) {
+                if (privacy_settings == null) {
+                    privacy_settings = new GLib.Settings ("org.gnome.desktop.privacy");
+                }
+
+                return privacy_settings.get_boolean ("remember-recent-files");
+            }
+
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
A lot of our apps are not testing if privacy mode is enabled to prevent things like recent files from showing up. But adding a settings dependency to `org.gnome.desktop.privacy` on every app that wants to check if privacy mode is enabled could be prevented by a helper function in Granite. This PR adds said function, and makes is to that if the setting is not found (Different OS or maybe GNOME changed the schema) it will just return `true` and the apps can act as normal
 
## Use cases: 

Terminal: PR to stop Tabs from being saved https://github.com/elementary/terminal/pull/349
Spice-Up: Stop saving the used files while it's enabled: https://github.com/Philip-Scott/Spice-up/pull/260
Videos also has the direct dependency at tihs line on [Window.vala](https://github.com/elementary/videos/blob/59dc6d61b0ad4a7e91cdda076169cd328f58a0c8/src/Window.vala#L407)