### PR TITLE
Require Meson >=0.48.2 Part 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ built for elementary OS.
 ## Building, Testing, and Installation
 
 You'll need the following dependencies:
-* meson
+* meson >= 0.48.2
 * gobject-introspection
 * libgee-0.8-dev
 * libgirepository1.0-dev


### PR DESCRIPTION
This completes #265 and #266 by adding the new meson requirement to the build dependencies in README.md