### PR TITLE
System: deprecate utilies provided by GLib

### DIFF
--- a/lib/Services/System.vala
+++ b/lib/Services/System.vala
@@ -18,57 +18,74 @@
  */
 
 namespace Granite.Services {
-
     /**
      * Utility class for frequently-used system-related functions, such as opening files, launching
      * applications, or executing terminal commands.
      */
     public class System : GLib.Object {
-    
+
         /**
          * Opens the specified URI with the default application.  This can be used for opening websites
          * with the default browser, etc.
          *
          * @param uri the URI to open
          */
+        [Version (deprecated = true, deprecated_since = "5.2.3", replacement = "GLib.AppInfo.launch_default_for_uri")]
         public static void open_uri (string uri) {
-            open (File.new_for_uri (uri));
+            try {
+                GLib.AppInfo.launch_default_for_uri (uri, null);
+            } catch (Error e) {
+                critical ("Failed to open uri: %s", e.message);
+            }
         }
-        
+
         /**
          * Opens the specified file with the default application.
          *
          * @param file the {@link GLib.File} to open
          */
+        [Version (deprecated = true, deprecated_since = "5.2.3", replacement = "GLib.AppInfo.launch_default_for_uri")]
         public static void open (File file) {
-            launch_with_files (null, { file });
+            try {
+                GLib.AppInfo.launch_default_for_uri (file.get_uri (), null);
+            } catch (Error e) {
+                critical ("Failed to open file: %s", e.message);
+            }
         }
-        
+
         /**
          * Opens the specified files with the default application.
          *
          * @param files an array of {@link GLib.File} to open
          */
+        [Version (deprecated = true, deprecated_since = "5.2.3", replacement = "GLib.AppInfo.launch_default_for_uri")]
         public static void open_files (File[] files) {
-            launch_with_files (null, files);
+            foreach (unowned GLib.File file in files) {
+                try {
+                    GLib.AppInfo.launch_default_for_uri (file.get_uri (), null);
+                } catch (Error e) {
+                    critical ("Failed to open file: %s", e.message);
+                }
+            }
         }
-        
+
         /**
          * Launches the specified application.
          *
          * @param app the {@link GLib.File} representing the application to launch
          */
+        [Version (deprecated = true, deprecated_since = "5.2.3", replacement = "GLib.AppInfo.launch")]
         public static void launch (File app) {
             launch_with_files (app, new File[] {});
         }
-        
+
         /**
          * Executes the specified command.
          *
          * @param command the command to execute
          */
+        [Version (deprecated = true, deprecated_since = "5.2.3", replacement = "AppInfo.create_from_commandline")]
         public static bool execute_command (string command) {
-        
             try {
                 var info = AppInfo.create_from_commandline (command, "", 0);
                 if (info.launch (null, null))
@@ -76,32 +93,32 @@ namespace Granite.Services {
             } catch (GLib.Error e) {
                 warning ("Failed to execute external '%s' command", command);
             }
-            
+
             return true;
         }
-        
+
         /**
          * Launches the supplied files with the specified application.
          *
          * @param app the {@link GLib.File} representing the application to launch
          * @param files an array of {@link GLib.File} to open
          */
+        [Version (deprecated = true, deprecated_since = "5.2.3", replacement = "GLib.AppInfo.launch")]
         public static void launch_with_files (File? app, File[] files) {
-        
             if (app != null && !app.query_exists ()) {
                 warning ("Application '%s' doesn't exist", app.get_path ());
                 return;
             }
-            
+
             var mounted_files = new GLib.List<File> ();
-            
+
             // make sure all files are mounted
             foreach (var f in files) {
                 if (f.get_path () != null && f.get_path () != "" && (f.is_native () || path_is_mounted (f.get_path ()))) {
                     mounted_files.append (f);
                     continue;
                 }
-                
+
                 try {
                     AppInfo.launch_default_for_uri (f.get_uri (), null);
                 } catch {
@@ -109,25 +126,23 @@ namespace Granite.Services {
                     mounted_files.append (f);
                 }
             }
-            
+
             if (mounted_files.length () > 0 || files.length == 0)
                 internal_launch (app, mounted_files);
         }
-        
+
         static bool path_is_mounted (string path) {
-        
             foreach (var m in VolumeMonitor.get ().get_mounts ())
                 if (m.get_root () != null && m.get_root ().get_path () != null && path.contains (m.get_root ().get_path ()))
                     return true;
-            
+
             return false;
         }
-        
+
         static void internal_launch (File? app, GLib.List<File> files) {
-        
             if (app == null && files.length () == 0)
                 return;
-            
+
             AppInfo info;
             if (app != null)
                 info = new DesktopAppInfo.from_filename (app.get_path ());
@@ -137,18 +152,18 @@ namespace Granite.Services {
                 } catch {
                     return;
                 }
-            
+
             try {
                 if (files.length () == 0) {
                     info.launch (null, null);
                     return;
                 }
-                
+
                 if (info.supports_files ()) {
                     info.launch (files, null);
                     return;
                 }
-                
+
                 if (info.supports_uris ()) {
                     var uris = new GLib.List<string> ();
                     foreach (var f in files)
@@ -156,7 +171,7 @@ namespace Granite.Services {
                     info.launch_uris (uris, new AppLaunchContext ());
                     return;
                 }
-                
+
                 error ("Error opening files. The application doesn't support files/URIs or wasn't found.");
             } catch (Error e) {
                 debug ("Error: " + e.domain.to_string ());

--- a/lib/Services/System.vala
+++ b/lib/Services/System.vala
@@ -30,7 +30,7 @@ namespace Granite.Services {
          *
          * @param uri the URI to open
          */
-        [Version (deprecated = true, deprecated_since = "5.2.3", replacement = "GLib.AppInfo.launch_default_for_uri")]
+        [Version (deprecated = true, deprecated_since = "5.2.4", replacement = "GLib.AppInfo.launch_default_for_uri")]
         public static void open_uri (string uri) {
             try {
                 GLib.AppInfo.launch_default_for_uri (uri, null);
@@ -44,7 +44,7 @@ namespace Granite.Services {
          *
          * @param file the {@link GLib.File} to open
          */
-        [Version (deprecated = true, deprecated_since = "5.2.3", replacement = "GLib.AppInfo.launch_default_for_uri")]
+        [Version (deprecated = true, deprecated_since = "5.2.4", replacement = "GLib.AppInfo.launch_default_for_uri")]
         public static void open (File file) {
             try {
                 GLib.AppInfo.launch_default_for_uri (file.get_uri (), null);
@@ -58,7 +58,7 @@ namespace Granite.Services {
          *
          * @param files an array of {@link GLib.File} to open
          */
-        [Version (deprecated = true, deprecated_since = "5.2.3", replacement = "GLib.AppInfo.launch_default_for_uri")]
+        [Version (deprecated = true, deprecated_since = "5.2.4", replacement = "GLib.AppInfo.launch_default_for_uri")]
         public static void open_files (File[] files) {
             foreach (unowned GLib.File file in files) {
                 try {
@@ -74,7 +74,7 @@ namespace Granite.Services {
          *
          * @param app the {@link GLib.File} representing the application to launch
          */
-        [Version (deprecated = true, deprecated_since = "5.2.3", replacement = "GLib.AppInfo.launch")]
+        [Version (deprecated = true, deprecated_since = "5.2.4", replacement = "GLib.AppInfo.launch")]
         public static void launch (File app) {
             launch_with_files (app, new File[] {});
         }
@@ -84,7 +84,7 @@ namespace Granite.Services {
          *
          * @param command the command to execute
          */
-        [Version (deprecated = true, deprecated_since = "5.2.3", replacement = "AppInfo.create_from_commandline")]
+        [Version (deprecated = true, deprecated_since = "5.2.4", replacement = "AppInfo.create_from_commandline")]
         public static bool execute_command (string command) {
             try {
                 var info = AppInfo.create_from_commandline (command, "", 0);
@@ -103,7 +103,7 @@ namespace Granite.Services {
          * @param app the {@link GLib.File} representing the application to launch
          * @param files an array of {@link GLib.File} to open
          */
-        [Version (deprecated = true, deprecated_since = "5.2.3", replacement = "GLib.AppInfo.launch")]
+        [Version (deprecated = true, deprecated_since = "5.2.4", replacement = "GLib.AppInfo.launch")]
         public static void launch_with_files (File? app, File[] files) {
             if (app != null && !app.query_exists ()) {
                 warning ("Application '%s' doesn't exist", app.get_path ());


### PR DESCRIPTION
All these utilities should be deprecated for a couple of reasons:

1. They're provided by GLib.AppInfo in few lines already so there's no real convenience benefit

2. These utilities don't return an Error and apps should really handle their errors in a more graceful way than just terminal output, with at least some kind of feedback in the UI.

Contents of the utilities have been replaced to not internally use deprecate methods so we don't get deprecation warnings when building Granite.