### PR TITLE
Utils: Add more keys to accel-to-string

### DIFF
--- a/lib/Widgets/Utils.vala
+++ b/lib/Widgets/Utils.vala
@@ -120,6 +120,14 @@ public static string accel_to_string (string accel) {
         case Gdk.Key.Right:
             arr += "→";
             break;
+        case Gdk.Key.Alt_L:
+            ///TRANSLATORS: The Alt key on the left side of the keyboard
+            arr += "Alt (Left)";
+            break;
+        case Gdk.Key.Alt_R:
+            ///TRANSLATORS: The Alt key on the right side of the keyboard
+            arr += "Alt (Right)";
+            break;
         case Gdk.Key.minus:
         case Gdk.Key.KP_Subtract:
             ///TRANSLATORS: This is a non-symbol representation of the "-" key
@@ -132,6 +140,14 @@ public static string accel_to_string (string accel) {
             break;
         case Gdk.Key.Return:
             arr += _("Enter");
+            break;
+        case Gdk.Key.Shift_L:
+            ///TRANSLATORS: The Shift key on the left side of the keyboard
+            arr += "Shift (Left)";
+            break;
+        case Gdk.Key.Shift_R:
+            ///TRANSLATORS: The Shift key on the right side of the keyboard
+            arr += "Shift (Right)";
             break;
         default:
             arr += Gtk.accelerator_get_label (accel_key, 0);

--- a/lib/Widgets/Utils.vala
+++ b/lib/Widgets/Utils.vala
@@ -122,11 +122,11 @@ public static string accel_to_string (string accel) {
             break;
         case Gdk.Key.Alt_L:
             ///TRANSLATORS: The Alt key on the left side of the keyboard
-            arr += "Alt (Left)";
+            arr += _("Left Alt");
             break;
         case Gdk.Key.Alt_R:
             ///TRANSLATORS: The Alt key on the right side of the keyboard
-            arr += "Alt (Right)";
+            arr += _("Right Alt");
             break;
         case Gdk.Key.minus:
         case Gdk.Key.KP_Subtract:
@@ -143,11 +143,11 @@ public static string accel_to_string (string accel) {
             break;
         case Gdk.Key.Shift_L:
             ///TRANSLATORS: The Shift key on the left side of the keyboard
-            arr += "Shift (Left)";
+            arr += _("Left Shift");
             break;
         case Gdk.Key.Shift_R:
             ///TRANSLATORS: The Shift key on the right side of the keyboard
-            arr += "Shift (Right)";
+            arr += _("Right Shift");
             break;
         default:
             arr += Gtk.accelerator_get_label (accel_key, 0);


### PR DESCRIPTION
Fixes #274 

Before: `Alt_L` is parsed to `Alt L`

After: `Alt_L` is parsed to `Alt (Left)`