### PR TITLE
MessageDialogView: Make copy more concise

### DIFF
--- a/demo/Views/MessageDialogView.vala
+++ b/demo/Views/MessageDialogView.vala
@@ -42,7 +42,7 @@ public class MessageDialogView : Gtk.Grid {
     }
 
     private void show_message_dialog () {
-        var message_dialog = new Granite.MessageDialog.with_image_from_icon_name ("Primary text providing basic information and a suggestion", "Secondary text providing further details. Also includes information that explains any unobvious consequences of actions.", "dialog-warning", Gtk.ButtonsType.CANCEL);
+        var message_dialog = new Granite.MessageDialog.with_image_from_icon_name ("Basic Information and a Suggestion", "Further details, including information that explains any unobvious consequences of actions.", "dialog-warning", Gtk.ButtonsType.CANCEL);
         message_dialog.transient_for = window;
         
         var suggested_button = new Gtk.Button.with_label ("Suggested Action");


### PR DESCRIPTION
Current copy is a big verbose. Also use Title Case while we're here

## BEFORE
![Screenshot from 2019-04-07 11 26 41@2x](https://user-images.githubusercontent.com/7277719/55687965-093bf900-5928-11e9-8634-28bdcf67582d.png)

## AFTER
![Screenshot from 2019-04-07 11 26 00@2x](https://user-images.githubusercontent.com/7277719/55687959-f75a5600-5927-11e9-884f-a80748c81344.png)
