### PR TITLE
Set headerbar foreground color with set_color_primary

### DIFF
--- a/demo/GraniteDemo.vala
+++ b/demo/GraniteDemo.vala
@@ -33,9 +33,13 @@ public class Granite.Demo : Gtk.Application {
     public override void activate () {
         var window = new Gtk.Window ();
 
+        var headerbar = new Gtk.HeaderBar ();
+        headerbar.get_style_context ().add_class ("default-decoration");
+        headerbar.show_close_button = true;
+
         var alert_view = new AlertViewView ();
         var avatar_view = new AvatarView ();
-        var css_view = new CSSView (window);
+        var css_view = new CSSView (headerbar);
         var date_time_picker_view = new DateTimePickerView ();
         var dynamic_notebook_view = new DynamicNotebookView ();
         var mode_button_view = new ModeButtonView ();
@@ -83,9 +87,6 @@ public class Granite.Demo : Gtk.Application {
         mode_switch.valign = Gtk.Align.CENTER;
         mode_switch.bind_property ("active", gtk_settings, "gtk_application_prefer_dark_theme");
 
-        var headerbar = new Gtk.HeaderBar ();
-        headerbar.get_style_context ().add_class ("default-decoration");
-        headerbar.show_close_button = true;
         headerbar.pack_end (mode_switch);
 
         window.add (paned);

--- a/demo/Views/CSSView.vala
+++ b/demo/Views/CSSView.vala
@@ -18,13 +18,15 @@
  */
 
 public class CSSView : Gtk.Grid {
-    public Gtk.Window window { get; construct; }
+    public Gtk.HeaderBar headerbar { get; construct; }
 
-    public CSSView (Gtk.Window window) {
-        Object (halign: Gtk.Align.CENTER,
-                valign: Gtk.Align.CENTER,
-                margin: 24,
-                window: window);
+    public CSSView (Gtk.HeaderBar headerbar) {
+        Object (
+            halign: Gtk.Align.CENTER,
+            valign: Gtk.Align.CENTER,
+            margin: 24,
+            headerbar: headerbar
+        );
     }
 
     construct {
@@ -115,7 +117,7 @@ public class CSSView : Gtk.Grid {
         attach (accent_color_grid, 1, 5);
 
         primary_color_button.color_set.connect (() => {
-            Granite.Widgets.Utils.set_color_primary (window, primary_color_button.rgba);
+            Granite.Widgets.Utils.set_brand_color ((Gtk.Widget) headerbar, primary_color_button.rgba);
         });
     }
 }

--- a/demo/Views/CSSView.vala
+++ b/demo/Views/CSSView.vala
@@ -117,7 +117,7 @@ public class CSSView : Gtk.Grid {
         attach (accent_color_grid, 1, 5);
 
         primary_color_button.color_set.connect (() => {
-            Granite.Widgets.Utils.set_brand_color ((Gtk.Widget) headerbar, primary_color_button.rgba);
+            Granite.Widgets.Utils.set_brand_color (headerbar, primary_color_button.rgba);
         });
     }
 }

--- a/demo/Views/UtilsView.vala
+++ b/demo/Views/UtilsView.vala
@@ -18,20 +18,86 @@
 */
 
 public class UtilsView : Gtk.Grid {
+    private const string CSS = """
+        .contrast-demo {
+            padding: 0.5em 1em;
+        }
+
+        .dark {
+            background-color: %s;
+            color: %s;
+        }
+
+        .light {
+            background-color: %s;
+            color: %s;
+        }
+    """;
+    private const string DARK_BG = "#273445";
+    private const string LIGHT_BG = "#d1ff82";
+
     construct {
         var tooltip_markup_label = new Gtk.Label ("Markup Accel Tooltips:");
         tooltip_markup_label.halign = Gtk.Align.END;
 
-        var button_one = new Gtk.Button.from_icon_name ("mail-reply-all", Gtk.IconSize.LARGE_TOOLBAR);
-        button_one.tooltip_markup = Granite.markup_accel_tooltip ({"<Ctrl><Shift>R"}, "Reply All");
+        var tooltip_button_one = new Gtk.Button.from_icon_name ("mail-reply-all", Gtk.IconSize.LARGE_TOOLBAR);
+        tooltip_button_one.tooltip_markup = Granite.markup_accel_tooltip ({"<Ctrl><Shift>R"}, "Reply All");
 
-        var button_two = new Gtk.Button.with_label ("Label Buttons");
-        button_two.tooltip_markup = Granite.markup_accel_tooltip ({"<Super>R", "<Ctrl><Shift>Up", "<Ctrl>Return"});
+        var tooltip_button_two = new Gtk.Button.with_label ("Label Buttons");
+        tooltip_button_two.tooltip_markup = Granite.markup_accel_tooltip ({"<Super>R", "<Ctrl><Shift>Up", "<Ctrl>Return"});
+
+        var contrasting_foreground_color_label = new Gtk.Label ("Contrasting Foreground Color:");
+        contrasting_foreground_color_label.halign = Gtk.Align.END;
+
+        var color_demo_dark = new Gtk.Label ("Dark Background");
+
+        var color_demo_dark_context = color_demo_dark.get_style_context ();
+        color_demo_dark_context.add_class (Granite.STYLE_CLASS_CARD);
+        color_demo_dark_context.add_class ("contrast-demo");
+        color_demo_dark_context.add_class ("dark");
+
+        var color_demo_light = new Gtk.Label ("Light Background");
+
+        var color_demo_light_context = color_demo_light.get_style_context ();
+        color_demo_light_context.add_class (Granite.STYLE_CLASS_CARD);
+        color_demo_light_context.add_class ("contrast-demo");
+        color_demo_light_context.add_class ("light");
 
         halign = valign = Gtk.Align.CENTER;
         column_spacing = 12;
-        add (tooltip_markup_label);
-        add (button_one);
-        add (button_two);
+        row_spacing = 12;
+
+        attach (tooltip_markup_label, 0, 0);
+        attach (tooltip_button_one, 1, 0);
+        attach (tooltip_button_two, 2, 0);
+        attach (contrasting_foreground_color_label, 0, 1);
+        attach (color_demo_dark, 1, 1);
+        attach (color_demo_light, 2, 1);
+
+        var provider = new Gtk.CssProvider ();
+        try {
+            var gdk_dark_bg = Gdk.RGBA ();
+            gdk_dark_bg.parse (DARK_BG);
+
+            var gdk_light_bg = Gdk.RGBA ();
+            gdk_light_bg.parse (LIGHT_BG);
+
+            var css = CSS.printf (
+                DARK_BG,
+                Granite.contrasting_foreground_color (gdk_dark_bg).to_string (),
+                LIGHT_BG,
+                Granite.contrasting_foreground_color (gdk_light_bg).to_string ()
+            );
+
+            provider.load_from_data (css, css.length);
+            Gtk.StyleContext.add_provider_for_screen (
+                Gdk.Screen.get_default (),
+                provider,
+                Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
+            );
+        } catch (GLib.Error e) {
+            critical (e.message);
+            return;
+        }
     }
 }

--- a/lib/Widgets/Utils.vala
+++ b/lib/Widgets/Utils.vala
@@ -272,19 +272,15 @@ public static Gdk.RGBA contrasting_foreground_color (Gdk.RGBA bg_color) {
  * This namespace contains functions to apply CSS stylesheets to widgets.
  */
 namespace Granite.Widgets.Utils {
-    private static Gdk.RGBA invert_color (Gdk.RGBA color) {
-        color = {1.0 - color.red, 1.0 - color.green, 1.0 - color.blue, color.alpha};
-
-        return color;
-    }
-
     /**
-     * Sets the colorPrimary, textColorPrimary, and textColorPrimaryShadow Gtk.CSS variables for the window.
-     * In the elementary stylesheet, these variables affect the background and foreground colors of the
-     * {@link Gtk.HeaderBar} so the application window can have a distinct brand color.
+     * Applies colorPrimary property to the window. The colorPrimary property currently changes
+     * the color of the {@link Gtk.HeaderBar} and it's children so that the application window
+     * can have a so-called "brand color".
+     *
+     * Note that this currently only works with the default stylesheet that elementary OS uses.
      *
      * @param window the widget to apply the color, for most cases the widget will be actually the {@link Gtk.Window} itself
-     * @param color the brand color to apply
+     * @param color the color to apply
      * @param priority priorty of change, by default {@link Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION}
      *
      * @return the added {@link Gtk.CssProvider}, or null in case the parsing of
@@ -293,19 +289,77 @@ namespace Granite.Widgets.Utils {
     public Gtk.CssProvider? set_color_primary (Gtk.Widget window, Gdk.RGBA color, int priority = Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION) {
         assert (window != null);
 
+        string hex = color.to_string ();
+        return set_theming_for_screen (window.get_screen (), @"@define-color colorPrimary $hex;", priority);
+    }
+
+    /**
+     * Attempts to set the given Gtk stylesheet variant on the given widget and its children.
+     *
+     * @param widget the {@link Gtk.Widget} on which to apply the stylesheet variant
+     * @param variant variant to load, for example, "dark", or null for the default
+     */
+    public static void set_variant (Gtk.Widget widget, string? variant = null) {
+        var gtk_settings = Gtk.Settings.get_default ();
+
+        try {
+            var css_provider = Gtk.CssProvider.get_named (gtk_settings.gtk_theme_name, variant);
+            widget.get_style_context ().add_provider (css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+        } catch (Error e) {}
+
+        if (widget is Gtk.Container) {
+            var container = (Gtk.Container) widget;
+            container.forall ((child) => {
+                set_variant (child, variant);
+            });
+        }
+    }
+
+    /**
+     * Sets the colorPrimary Gtk.CSS variables for the given titlebar, as well as the light or dark stylesheet
+     * variant for the titlebar depending on the luminance of the provided color. In the elementary stylesheet,
+     * this affects the background and foreground colors of the titlebar.
+     *
+     * @param titlebar the titlebar {@link Gtk.Widget} on which to apply the brand color
+     * @param color the brand color to apply
+     * @param priority priorty of change, by default {@link Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION}
+     *
+     * @return true if successful, false if not.
+     */
+    public static bool set_brand_color (Gtk.Widget titlebar, Gdk.RGBA color, int priority = Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION) {
+        assert (titlebar != null);
+
         string bg = color.to_string ();
         string fg = contrasting_foreground_color (color).to_string ();
-        string fg_shadow = invert_color (contrasting_foreground_color (color)).to_string ();
 
-        return set_theming_for_screen (
-            window.get_screen (),
+        var provider = set_theming (
+            titlebar,
             @"
                 @define-color colorPrimary $bg;
-                @define-color textColorPrimary $fg;
-                @define-color textColorPrimaryShadow alpha($fg_shadow, 0.4);
             ",
+            null,
             priority
         );
+
+        // FIXME: can't use both set_variant and set_theming
+        if (provider != null) {
+            switch (fg) {
+                case "rgb(255,255,255)":
+                    // Light text on dark bg
+                    set_variant (titlebar, "dark");
+                    critical ("dark: %s on %s", fg, bg);
+                    break;
+                default:
+                    // Dark text on light bg
+                    set_variant (titlebar);
+                    critical ("light: %s on %s", fg, bg);
+                    break;
+            }
+
+            return true;
+        }
+
+        return false;
     }
 
     /**

--- a/lib/Widgets/Utils.vala
+++ b/lib/Widgets/Utils.vala
@@ -204,7 +204,7 @@ public static string markup_accel_tooltip (string[]? accels, string? description
     return string.joinv ("\n", parts);
 }
 
-private double contrast_ratio (Gdk.RGBA bg_color, Gdk.RGBA fg_color) {
+private static double contrast_ratio (Gdk.RGBA bg_color, Gdk.RGBA fg_color) {
     var bg_luminance = get_luminance (bg_color);
     var fg_luminance = get_luminance (fg_color);
 
@@ -215,15 +215,15 @@ private double contrast_ratio (Gdk.RGBA bg_color, Gdk.RGBA fg_color) {
     return (fg_luminance + 0.05) / (bg_luminance + 0.05);
 }
 
-private double get_luminance (Gdk.RGBA color) {
+private static double get_luminance (Gdk.RGBA color) {
     var red = sanitize_color (color.red) * 0.2126;
     var green = sanitize_color (color.green) * 0.7152;
     var blue = sanitize_color (color.blue) * 0.0722;
 
-    return (red + green + blue);
+    return red + green + blue;
 }
 
-private double sanitize_color (double color) {
+private static double sanitize_color (double color) {
     if (color <= 0.03928) {
         return color / 12.92;
     }
@@ -232,18 +232,15 @@ private double sanitize_color (double color) {
 }
 
 /**
- * Takes a {@link Gdk.RGBA} background color and returns a suitably-contrasting foreground color, i.e. for determining text color on a colored background.
+ * Takes a {@link Gdk.RGBA} background color and returns a suitably-contrasting foreground color, i.e. for determining text color on a colored background. There is a slight bias toward returning white, as white generally looks better on a wider range of colored backgrounds than black.
  *
- * @param bg_color a {@link Gdk.RGBA} background color
+ * @param bg_color any {@link Gdk.RGBA} background color
  *
- * @return a contrasting {@link Gdk.RGBA} foreground color
+ * @return a contrasting {@link Gdk.RGBA} foreground color, i.e. white ({ 1.0, 1.0, 1.0, 1.0}) or black ({ 0.0, 0.0, 0.0, 0.0}).
  */
 public static Gdk.RGBA contrasting_foreground_color (Gdk.RGBA bg_color) {
-    var gdk_white = Gdk.RGBA ();
-    gdk_white.parse ("#fff");
-
-    var gdk_black = Gdk.RGBA ();
-    gdk_black.parse ("#000");
+    Gdk.RGBA gdk_white = { 1.0, 1.0, 1.0, 1.0 };
+    Gdk.RGBA gdk_black = { 0.0, 0.0, 0.0, 1.0 };
 
     var contrast_with_white = contrast_ratio (
         bg_color,

--- a/lib/Widgets/Utils.vala
+++ b/lib/Widgets/Utils.vala
@@ -236,7 +236,7 @@ private static double sanitize_color (double color) {
  *
  * @param bg_color any {@link Gdk.RGBA} background color
  *
- * @return a contrasting {@link Gdk.RGBA} foreground color, i.e. white ({ 1.0, 1.0, 1.0, 1.0}) or black ({ 0.0, 0.0, 0.0, 0.0}).
+ * @return a contrasting {@link Gdk.RGBA} foreground color, i.e. white ({ 1.0, 1.0, 1.0, 1.0}) or black ({ 0.0, 0.0, 0.0, 1.0}).
  */
 public static Gdk.RGBA contrasting_foreground_color (Gdk.RGBA bg_color) {
     Gdk.RGBA gdk_white = { 1.0, 1.0, 1.0, 1.0 };

--- a/lib/Widgets/Utils.vala
+++ b/lib/Widgets/Utils.vala
@@ -316,24 +316,24 @@ namespace Granite.Widgets.Utils {
     }
 
     /**
-     * Sets the colorPrimary Gtk.CSS variables for the given titlebar, as well as the light or dark stylesheet
-     * variant for the titlebar depending on the luminance of the provided color. In the elementary stylesheet,
-     * this affects the background and foreground colors of the titlebar.
+     * Sets the colorPrimary Gtk.CSS variable for the given {@link Gtk.HeaderBar}, as well as the light or dark
+     * stylesheet variant for the titlebar depending on the luminance of the provided color. In the elementary
+     * stylesheet, this affects the background and foreground colors of the {@link Gtk.HeaderBar}.
      *
-     * @param titlebar the titlebar {@link Gtk.Widget} on which to apply the brand color
+     * @param titlebar the headerbar {@link Gtk.HeaderBar} on which to apply the brand color
      * @param color the brand color to apply
      * @param priority priorty of change, by default {@link Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION}
      *
      * @return true if successful, false if not.
      */
-    public static bool set_brand_color (Gtk.Widget titlebar, Gdk.RGBA color, int priority = Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION) {
-        assert (titlebar != null);
+    public static bool set_brand_color (Gtk.HeaderBar headerbar, Gdk.RGBA color, int priority = Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION) {
+        assert (headerbar != null);
 
         string bg = color.to_string ();
         string fg = contrasting_foreground_color (color).to_string ();
 
         var provider = set_theming (
-            titlebar,
+            headerbar,
             @"
                 @define-color colorPrimary $bg;
             ",
@@ -346,12 +346,12 @@ namespace Granite.Widgets.Utils {
             switch (fg) {
                 case "rgb(255,255,255)":
                     // Light text on dark bg
-                    set_variant (titlebar, "dark");
+                    set_variant (headerbar, "dark");
                     critical ("dark: %s on %s", fg, bg);
                     break;
                 default:
                     // Dark text on light bg
-                    set_variant (titlebar);
+                    set_variant (headerbar);
                     critical ("light: %s on %s", fg, bg);
                     break;
             }

--- a/lib/Widgets/Utils.vala
+++ b/lib/Widgets/Utils.vala
@@ -317,16 +317,20 @@ namespace Granite.Widgets.Utils {
 
     /**
      * Sets the colorPrimary Gtk.CSS variable for the given {@link Gtk.HeaderBar}, as well as the light or dark
-     * stylesheet variant for the titlebar depending on the luminance of the provided color. In the elementary
+     * stylesheet variant for the headerbar depending on the luminance of the provided color. In the elementary
      * stylesheet, this affects the background and foreground colors of the {@link Gtk.HeaderBar}.
      *
      * @param titlebar the headerbar {@link Gtk.HeaderBar} on which to apply the brand color
      * @param color the brand color to apply
      * @param priority priorty of change, by default {@link Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION}
      *
-     * @return true if successful, false if not.
+     * @return //true// if successful, //false// if not.
      */
-    public static bool set_brand_color (Gtk.HeaderBar headerbar, Gdk.RGBA color, int priority = Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION) {
+    public static bool set_brand_color (
+        Gtk.HeaderBar headerbar,
+        Gdk.RGBA color,
+        int priority = Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
+    ) {
         assert (headerbar != null);
 
         string bg = color.to_string ();
@@ -334,9 +338,7 @@ namespace Granite.Widgets.Utils {
 
         var provider = set_theming (
             headerbar,
-            @"
-                @define-color colorPrimary $bg;
-            ",
+            @"@define-color colorPrimary $bg;",
             null,
             priority
         );
@@ -344,6 +346,8 @@ namespace Granite.Widgets.Utils {
         // FIXME: can't use both set_variant and set_theming
         if (provider != null) {
             switch (fg) {
+                // FIXME: This seems dirty/indirect. New reusable method to
+                // determine if a color is light or dark?
                 case "rgb(255,255,255)":
                     // Light text on dark bg
                     set_variant (headerbar, "dark");


### PR DESCRIPTION
Builds off of https://github.com/elementary/granite/pull/284. I thought it made sense here since I frequently see brand colors without properly-contrasting foreground colors.