### PR TITLE
Fix #294: Rapidly closing tabs with three-finger/middle click button re-opens closed tabs

### DIFF
--- a/lib/Widgets/DynamicNotebook.vala
+++ b/lib/Widgets/DynamicNotebook.vala
@@ -301,9 +301,8 @@ namespace Granite.Widgets {
             });
 
             this.button_press_event.connect ((e) => {
-                if (e.button == 2 && close_button_is_visible ()) {
+                if (e.button == 2) {
                     e.state &= MODIFIER_MASK;
-
                     if  (e.state == 0) {
                         this.closed ();
                     } else if (e.state == Gdk.ModifierType.SHIFT_MASK) {
@@ -386,10 +385,6 @@ namespace Granite.Widgets {
 
             close_button_revealer.reveal_child = _closable && !_pinned
                 && (cursor_over_tab || cursor_over_close_button || _is_current_tab);
-        }
-
-        private bool close_button_is_visible () {
-            return close_button_revealer.visible && close_button_revealer.reveal_child;
         }
     }
 

--- a/lib/Widgets/DynamicNotebook.vala
+++ b/lib/Widgets/DynamicNotebook.vala
@@ -389,7 +389,7 @@ namespace Granite.Widgets {
         }
 
         private bool close_button_is_visible () {
-            return close_button_revealer.visible && close_button_revealer.child_revealed;
+            return close_button_revealer.visible && close_button_revealer.reveal_child;
         }
     }
 


### PR DESCRIPTION
Fix for #294 and https://github.com/elementary/code/issues/485: Dynamic notebook: Rapidly closing tabs with three-finger/middle
click button re-opens closed tabs

Changing `child_revealed` to `reveal_child` to make tab close-able by middle/three-finger click during
reveal animation. This prevents the creation of new tabs when trying to rapidly close multiple tabs.

**Before**

![RAPID_CLICKING](https://user-images.githubusercontent.com/24651767/60677085-d51d9900-9e80-11e9-88a8-98d1dca1942c.gif)

**After**

![RAPID_CLICKING_FIX](https://user-images.githubusercontent.com/24651767/60677092-da7ae380-9e80-11e9-91f9-4b12b084e250.gif)



