### PR TITLE
Remove path from --shared-library flag

### DIFF
--- a/lib/meson.build
+++ b/lib/meson.build
@@ -102,11 +102,12 @@ custom_target(
     command: [
         g_ir_compiler,
         '--shared-library',
-        libgranite.full_path(),
+        '@PLAINNAME@',
         '--output',
         '@OUTPUT@',
         join_paths(meson.current_build_dir(), granite_gir),
     ],
+    input: libgranite,
     output: granite_typelib,
     depends: libgranite,
     install: true,


### PR DESCRIPTION
See issue #241 for context.
Passing libgranite.full_path() to g-ir-compiler during the build
results in a typelib which references the local build path, which
doesn't correspond to the actual build path in the binary that's
shipped to the users in the packaged version of libgranite.
Removing the path component and leaving only the output library
filename here still works as expected.