### PR TITLE
More efficient closing other tabs

### DIFF
--- a/lib/Widgets/DynamicNotebook.vala
+++ b/lib/Widgets/DynamicNotebook.vala
@@ -1191,11 +1191,12 @@ namespace Granite.Widgets {
         }
 
         private void on_close_others (Tab clicked_tab) {
-            tabs.copy ().foreach ((tab) => {
+            for (unowned List<Tab> list = tabs; list != null; list = list.next) {
+                var tab = list.data;
                 if (tab != clicked_tab) {
                     tab.closed ();
                 }
-            });
+            }
         }
 
         private void on_close_others_right (Tab clicked_tab) {


### PR DESCRIPTION
No need for copying the tab list. Just iterate and remove all other tabs.