### PR TITLE
Revert "More efficient code for closing to the right"

### DIFF
--- a/lib/Widgets/DynamicNotebook.vala
+++ b/lib/Widgets/DynamicNotebook.vala
@@ -1199,11 +1199,16 @@ namespace Granite.Widgets {
         }
 
         private void on_close_others_right (Tab clicked_tab) {
-            unowned List<Tab> list = tabs.find (clicked_tab).next;
+            var is_to_the_right = false; 
 
-            for (; list != null; list = list.next) {
-                list.data.closed ();
-            }
+            tabs.copy ().foreach ((tab) => {
+                if (is_to_the_right) {
+                    tab.closed ();
+                }
+                if (tab == clicked_tab) {
+                    is_to_the_right = true;
+                }
+            });
         }
 
         private void on_new_window (Tab tab) {


### PR DESCRIPTION
Reverts elementary/granite#299

It seems like this causes segfaults in Code which were also foresighted by the discussion in https://github.com/elementary/granite/pull/301. Oops.