### PR TITLE
Add test and lint stages to ci process.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,14 @@ env:
  - DEPENDENCY_PACKAGES="meson gobject-introspection libgee-0.8-dev libgirepository1.0-dev libgtk-3-dev valac"
 
 install:
- - docker pull elementary/docker:juno-unstable
- - docker run -v "$PWD":/tmp/build-dir elementary/docker:juno-unstable /bin/sh -c "apt-get update && apt-get -y install $DEPENDENCY_PACKAGES && cd /tmp/build-dir && meson build && cd build && ninja"
+ - docker run -v "$PWD":/tmp/build-dir elementary/docker:juno-unstable /bin/sh -c "apt-get update && apt-get -y install $DEPENDENCY_PACKAGES && cd /tmp/build-dir && meson build && ninja -C build"
 
-script:
- - echo BUILDS PASSED
+jobs:
+  include:
+    - stage: "Test"
+      script:
+        - docker run -v "$PWD":/tmp/build-dir elementary/docker:juno-unstable /bin/sh -c "cd /tmp/build-dir && ninja test -C build"
+
+    - stage: "Lint"
+      script:
+        - docker run -v "$PWD":/var/opt/vala-lint elementary/docker:vala-lint io.elementary.vala-lint -d .

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ jobs:
 
     - stage: "Lint"
       script:
-        - docker run -v "$PWD":/var/opt/vala-lint elementary/docker:vala-lint io.elementary.vala-lint -d .
+        - docker run -v "$PWD":/app valalang/lint io.elementary.vala-lint -d .


### PR DESCRIPTION
This change adds 2 new stages to the travis ci pipeline:

1. **Test:** This will run `ninja test -C build`. Right now, Granite doesn't have any tests, but as soon as tests are created, this should pick them up.
1. **Lint:** This will run `io.elementary.vala-lint -d .`, which will lint all vala code and report any warnings/errors.

**_NOTE_**: This pr's lint stage will fail until this repo is vala-lint compliant. To track progress on lint compliance, take a look at #317. 