### PR TITLE
Use window-close-symbolic in toasts

### DIFF
--- a/lib/Widgets/Toast.vala
+++ b/lib/Widgets/Toast.vala
@@ -85,7 +85,7 @@ namespace Granite.Widgets {
                 default_action ();
             });
 
-            var close_button = new Gtk.Button.from_icon_name ("close-symbolic", Gtk.IconSize.MENU);
+            var close_button = new Gtk.Button.from_icon_name ("window-close-symbolic", Gtk.IconSize.MENU);
             close_button.get_style_context ().add_class ("close-button");
             close_button.clicked.connect (() => {
                 reveal_child = false;


### PR DESCRIPTION
…instead of `close-symbolic`. This icon is provided by Adwaita and Yaru. It's also self-consistent since we use it in Dynamic Notebooks:

https://github.com/elementary/granite/blob/40e7d08c0fb7921104a1f2d362e8862dabc02c8c/lib/Widgets/DynamicNotebook.vala#L238

We symlink it in the icons anyway: https://github.com/elementary/icons/blob/master/actions/symbolic/close-symbolic.svg