### PR TITLE
Use async mutex for badge synchronisation

### DIFF
--- a/lib/Services/AsyncMutex.vala
+++ b/lib/Services/AsyncMutex.vala
@@ -1,0 +1,57 @@
+/*
+* Copyright 2019 elementary, Inc. (https://elementary.io)
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public
+* License as published by the Free Software Foundation; either
+* version 3 of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* General Public License for more details.
+*
+* You should have received a copy of the GNU General Public
+* License along with this program; if not, write to the
+* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+* Boston, MA 02110-1301 USA
+*
+*/
+
+namespace Granite.Services {
+    internal class AsyncMutex {
+        private class Callback {
+            public SourceFunc callback;
+
+            public Callback (owned SourceFunc cb) {
+                callback = (owned)cb;
+            }
+        }
+
+        private Gee.ArrayQueue<Callback> callbacks;
+        private bool locked;
+
+        public AsyncMutex () {
+            locked = false;
+            callbacks = new Gee.ArrayQueue<Callback> ();
+        }
+
+        public async void lock () {
+            while (locked) {
+                SourceFunc cb = lock.callback;
+                callbacks.offer_head (new Callback ((owned)cb));
+                yield;
+            }
+
+            locked = true;
+        }
+
+        public void unlock () {
+            locked = false;
+            var callback = callbacks.poll_head ();
+            if (callback != null) {
+                Idle.add ((owned)callback.callback);
+            }
+        }
+    }
+}

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -10,6 +10,7 @@ libgranite_sources = files(
     'GtkPatch/AboutDialog.vala',
 
     'Services/Application.vala',
+    'Services/AsyncMutex.vala',
     'Services/ContractorProxy.vala',
     'Services/IconFactory.vala',
     'Services/Logger.vala',


### PR DESCRIPTION
The `lock` keyword only locks across different threads, rather than different calls to `async` methods on the same thread.

We were seeing an issue with AppCenter where the badge wouldn't appear and we'd get the following messages in the console:
```
Client.vala:95: An object is already exported for the interface com.canonical.Unity.LauncherEntry at /com/canonical/unity/launcherentry/3980099301
```

This was due to a race condition where `set_badge` and `set_badge_visible` were called in quick succession to each other.

In this case, the first call is still yielding on `GLib.Bus.@get` with `instance = null`, the second call sees that `instance == null` and continues to try and create a new instance and register on the bus again, which fails.

I've created this generalized async locking class that solves these kinds of issues. I've made it an internal API of Granite for now, but maybe we want to document this and make it public for other applications to use?