### PR TITLE
BufferSurface: Lint

### DIFF
--- a/lib/Drawing/BufferSurface.vala
+++ b/lib/Drawing/BufferSurface.vala
@@ -28,7 +28,7 @@ namespace Granite.Drawing {
      * for usage with large, rarely updated draw operations.
      */
     public class BufferSurface : GLib.Object {
-    
+
         private Surface _surface;
         /**
          * The {@link Cairo.Surface} which will store the results of all drawing operations
@@ -42,7 +42,7 @@ namespace Granite.Drawing {
             }
             private set { _surface = value; }
         }
-        
+
         /**
          * The width of the {@link Granite.Drawing.BufferSurface}, in pixels.
          */
@@ -51,7 +51,7 @@ namespace Granite.Drawing {
          * The height of the BufferSurface, in pixels.
          */
         public int height { get; private set; }
-        
+
         private Context _context;
         /**
          * The {@link Cairo.Context} for the internal surface. All drawing operations done on this
@@ -64,7 +64,7 @@ namespace Granite.Drawing {
                 return _context;
             }
         }
-        
+
         /**
          * Constructs a new, empty {@link Granite.Drawing.BufferSurface} with the supplied dimensions.
          *
@@ -72,7 +72,7 @@ namespace Granite.Drawing {
          * @param height the height of the {@link Granite.Drawing.BufferSurface}, in pixels
          */
         public BufferSurface (int width, int height) requires (width >= 0 && height >= 0) {
-        
+
             this.width = width;
             this.height = height;
         }
@@ -86,7 +86,7 @@ namespace Granite.Drawing {
          * @param model the {@link Cairo.Surface} to use as a model for the internal {@link Cairo.Surface}
          */
         public BufferSurface.with_surface (int width, int height, Surface model) requires (model != null) {
-        
+
             this (width, height);
             surface = new Surface.similar (model, Content.COLOR_ALPHA, width, height);
         }
@@ -100,49 +100,49 @@ namespace Granite.Drawing {
          * @param model the {@link Granite.Drawing.BufferSurface} to use as a model for the internal {@link Cairo.Surface}
          */
         public BufferSurface.with_buffer_surface (int width, int height, BufferSurface model) requires (model != null) {
-        
+
             this (width, height);
             surface = new Surface.similar (model.surface, Content.COLOR_ALPHA, width, height);
         }
-        
+
         /**
          * Clears the internal {@link Cairo.Surface}, making all pixels fully transparent.
          */
         public void clear () {
-        
+
             context.save ();
-            
+
             _context.set_source_rgba (0, 0, 0, 0);
             _context.set_operator (Operator.SOURCE);
             _context.paint ();
-            
+
             _context.restore ();
         }
-        
+
         /**
          * Creates a {@link Gdk.Pixbuf} from internal {@link Cairo.Surface}.
          *
          * @return the {@link Gdk.Pixbuf}
          */
         public Gdk.Pixbuf load_to_pixbuf () {
-        
+
             var image_surface = new ImageSurface (Format.ARGB32, width, height);
             var cr = new Cairo.Context (image_surface);
-            
+
             cr.set_operator (Operator.SOURCE);
             cr.set_source_surface (surface, 0, 0);
             cr.paint ();
-            
+
             var width = image_surface.get_width ();
             var height = image_surface.get_height ();
 
             var pb = new Gdk.Pixbuf (Gdk.Colorspace.RGB, true, 8, width, height);
             pb.fill (0x00000000);
-            
+
             uint8 *data = image_surface.get_data ();
             uint8 *pixels = pb.get_pixels ();
             var length = width * height;
-            
+
             if (image_surface.get_format () == Format.ARGB32) {
                 for (var i = 0; i < length; i++) {
                     // if alpha is 0 set nothing
@@ -152,7 +152,7 @@ namespace Granite.Drawing {
                         pixels[2] = (uint8) (data[0] * 255 / data[3]);
                         pixels[3] = data[3];
                     }
-        
+
                     pixels += 4;
                     data += 4;
                 }
@@ -162,58 +162,58 @@ namespace Granite.Drawing {
                     pixels[1] = data[1];
                     pixels[2] = data[0];
                     pixels[3] = data[3];
-        
+
                     pixels += 4;
                     data += 4;
                 }
             }
-            
+
             return pb;
         }
-        
+
         /**
          * Averages all the colors in the internal {@link Cairo.Surface}.
          *
          * @return the {@link Granite.Drawing.Color} with the averaged color
          */
         public Drawing.Color average_color () {
-        
+
             var bTotal = 0.0;
             var gTotal = 0.0;
             var rTotal = 0.0;
-            
+
             var w = width;
             var h = height;
-            
+
             var original = new ImageSurface (Format.ARGB32, w, h);
             var cr = new Cairo.Context (original);
-            
+
             cr.set_operator (Operator.SOURCE);
             cr.set_source_surface (surface, 0, 0);
             cr.paint ();
-            
+
             uint8 *data = original.get_data ();
             var length = w * h;
-            
+
             for (var i = 0; i < length; i++) {
                 uint8 b = data [0];
                 uint8 g = data [1];
                 uint8 r = data [2];
-                
+
                 uint8 max = (uint8) double.max (r, double.max (g, b));
                 uint8 min = (uint8) double.min (r, double.min (g, b));
                 double delta = max - min;
-                
+
                 var sat = delta == 0 ? 0.0 : delta / max;
                 var score = 0.2 + 0.8 * sat;
-                
+
                 bTotal += b * score;
                 gTotal += g * score;
                 rTotal += r * score;
-                
+
                 data += 4;
             }
-            
+
             return new Drawing.Color (rTotal / uint8.MAX / length,
                              gTotal / uint8.MAX / length,
                              bTotal / uint8.MAX / length,
@@ -228,136 +228,136 @@ namespace Granite.Drawing {
          * @param process_count the number of times to perform the operation
          */
         public void fast_blur (int radius, int process_count = 1) {
-        
+
             if (radius < 1 || process_count < 1)
                 return;
-            
+
             var w = width;
             var h = height;
             var channels = 4;
-            
+
             if (radius > w - 1 || radius > h - 1)
                 return;
-            
+
             var original = new ImageSurface (Format.ARGB32, w, h);
             var cr = new Cairo.Context (original);
-            
+
             cr.set_operator (Operator.SOURCE);
             cr.set_source_surface (surface, 0, 0);
             cr.paint ();
-            
+
             uint8 *pixels = original.get_data ();
             var buffer = new uint8[w * h * channels];
-            
+
             var vmin = new int[int.max (w, h)];
             var vmax = new int[int.max (w, h)];
-            
+
             var div = 2 * radius + 1;
             var dv = new uint8[256 * div];
             for (var i = 0; i < dv.length; i++)
                 dv[i] = (uint8) (i / div);
-            
+
             while (process_count-- > 0) {
                 for (var x = 0; x < w; x++) {
                     vmin[x] = int.min (x + radius + 1, w - 1);
                     vmax[x] = int.max (x - radius, 0);
                 }
-                
+
                 for (var y = 0; y < h; y++) {
                     var asum = 0, rsum = 0, gsum = 0, bsum = 0;
-                    
+
                     uint32 cur_pixel = y * w * channels;
-                                        
+
                     asum += radius * pixels[cur_pixel + 0];
                     rsum += radius * pixels[cur_pixel + 1];
                     gsum += radius * pixels[cur_pixel + 2];
                     bsum += radius * pixels[cur_pixel + 3];
-                    
+
                     for (var i = 0; i <= radius; i++) {
                         asum += pixels[cur_pixel + 0];
                         rsum += pixels[cur_pixel + 1];
                         gsum += pixels[cur_pixel + 2];
                         bsum += pixels[cur_pixel + 3];
-                        
+
                         cur_pixel += channels;
                     }
-                    
+
                     cur_pixel = y * w * channels;
-                                        
+
                     for (var x = 0; x < w; x++) {
                         uint32 p1 = (y * w + vmin[x]) * channels;
                         uint32 p2 = (y * w + vmax[x]) * channels;
-                        
+
                         buffer[cur_pixel + 0] = dv[asum];
                         buffer[cur_pixel + 1] = dv[rsum];
                         buffer[cur_pixel + 2] = dv[gsum];
                         buffer[cur_pixel + 3] = dv[bsum];
-                        
+
                         asum += pixels[p1 + 0] - pixels[p2 + 0];
                         rsum += pixels[p1 + 1] - pixels[p2 + 1];
                         gsum += pixels[p1 + 2] - pixels[p2 + 2];
                         bsum += pixels[p1 + 3] - pixels[p2 + 3];
-                        
+
                         cur_pixel += channels;
                     }
                 }
-                
+
                 for (var y = 0; y < h; y++) {
                     vmin[y] = int.min (y + radius + 1, h - 1) * w;
                     vmax[y] = int.max (y - radius, 0) * w;
                 }
-                
+
                 for (var x = 0; x < w; x++) {
                     var asum = 0, rsum = 0, gsum = 0, bsum = 0;
-                    
+
                     uint32 cur_pixel = x * channels;
-                    
+
                     asum += radius * buffer[cur_pixel + 0];
                     rsum += radius * buffer[cur_pixel + 1];
                     gsum += radius * buffer[cur_pixel + 2];
                     bsum += radius * buffer[cur_pixel + 3];
-                    
+
                     for (var i = 0; i <= radius; i++) {
                         asum += buffer[cur_pixel + 0];
                         rsum += buffer[cur_pixel + 1];
                         gsum += buffer[cur_pixel + 2];
                         bsum += buffer[cur_pixel + 3];
-                        
+
                         cur_pixel += w * channels;
                     }
-                    
+
                     cur_pixel = x * channels;
-                    
+
                     for (var y = 0; y < h; y++) {
                         uint32 p1 = (x + vmin[y]) * channels;
                         uint32 p2 = (x + vmax[y]) * channels;
-                        
+
                         pixels[cur_pixel + 0] = dv[asum];
                         pixels[cur_pixel + 1] = dv[rsum];
                         pixels[cur_pixel + 2] = dv[gsum];
                         pixels[cur_pixel + 3] = dv[bsum];
-                        
+
                         asum += buffer[p1 + 0] - buffer[p2 + 0];
                         rsum += buffer[p1 + 1] - buffer[p2 + 1];
                         gsum += buffer[p1 + 2] - buffer[p2 + 2];
                         bsum += buffer[p1 + 3] - buffer[p2 + 3];
-                        
+
                         cur_pixel += w * channels;
                     }
                 }
             }
-            
+
             original.mark_dirty ();
-            
+
             context.set_operator (Operator.SOURCE);
             context.set_source_surface (original, 0, 0);
             context.paint ();
             context.set_operator (Operator.OVER);
         }
-        
+
         const int AlphaPrecision = 16;
         const int ParamPrecision = 7;
-        
+
         /**
          * Performs a blur operation on the internal {@link Cairo.Surface}, using an
          * exponential blurring algorithm. This method is usually the fastest
@@ -366,23 +366,23 @@ namespace Granite.Drawing {
          * @param radius the blur radius
          */
         public void exponential_blur (int radius) {
-        
+
             if (radius < 1)
                 return;
-            
+
             var alpha = (int) ((1 << AlphaPrecision) * (1.0 - Math.exp (-2.3 / (radius + 1.0))));
             var height = this.height;
             var width = this.width;
-            
+
             var original = new ImageSurface (Format.ARGB32, width, height);
             var cr = new Cairo.Context (original);
-            
+
             cr.set_operator (Operator.SOURCE);
             cr.set_source_surface (surface, 0, 0);
             cr.paint ();
-            
+
             uint8 *pixels = original.get_data ();
-            
+
             try {
                 // Process Rows
                 var th = new Thread<void*>.try (null, () => {
@@ -392,7 +392,7 @@ namespace Granite.Drawing {
 
                 exponential_blur_rows (pixels, width, height, height / 2, height, 0, width, alpha);
                 th.join ();
-                
+
                 // Process Columns
                 var th2 = new Thread<void*>.try (null, () => {
                     exponential_blur_columns (pixels, width, height, 0, width / 2, 0, height, alpha);
@@ -404,70 +404,70 @@ namespace Granite.Drawing {
             } catch (Error err) {
                 warning (err.message);
             }
-            
+
             original.mark_dirty ();
-            
+
             context.set_operator (Operator.SOURCE);
             context.set_source_surface (original, 0, 0);
             context.paint ();
             context.set_operator (Operator.OVER);
         }
-        
+
         void exponential_blur_columns (uint8* pixels, int width, int height, int startCol, int endCol, int startY, int endY, int alpha) {
-        
+
             for (var columnIndex = startCol; columnIndex < endCol; columnIndex++) {
                 // blur columns
                 uint8 *column = pixels + columnIndex * 4;
-                
+
                 var zA = column[0] << ParamPrecision;
                 var zR = column[1] << ParamPrecision;
                 var zG = column[2] << ParamPrecision;
                 var zB = column[3] << ParamPrecision;
-                
+
                 // Top to Bottom
                 for (var index = width * (startY + 1); index < (endY - 1) * width; index += width)
                     exponential_blur_inner (&column[index * 4], ref zA, ref zR, ref zG, ref zB, alpha);
-                
+
                 // Bottom to Top
                 for (var index = (endY - 2) * width; index >= startY; index -= width)
                     exponential_blur_inner (&column[index * 4], ref zA, ref zR, ref zG, ref zB, alpha);
             }
         }
-        
+
         void exponential_blur_rows (uint8* pixels, int width, int height, int startRow, int endRow, int startX, int endX, int alpha) {
-        
+
             for (var rowIndex = startRow; rowIndex < endRow; rowIndex++) {
                 // Get a pointer to our current row
                 uint8* row = pixels + rowIndex * width * 4;
-                
+
                 var zA = row[startX + 0] << ParamPrecision;
                 var zR = row[startX + 1] << ParamPrecision;
                 var zG = row[startX + 2] << ParamPrecision;
                 var zB = row[startX + 3] << ParamPrecision;
-                
+
                 // Left to Right
                 for (var index = startX + 1; index < endX; index++)
                     exponential_blur_inner (&row[index * 4], ref zA, ref zR, ref zG, ref zB, alpha);
-                
+
                 // Right to Left
                 for (var index = endX - 2; index >= startX; index--)
                     exponential_blur_inner (&row[index * 4], ref zA, ref zR, ref zG, ref zB, alpha);
             }
         }
-        
+
         private static inline void exponential_blur_inner (uint8* pixel, ref int zA, ref int zR, ref int zG, ref int zB, int alpha) {
-        
+
             zA += (alpha * ((pixel[0] << ParamPrecision) - zA)) >> AlphaPrecision;
             zR += (alpha * ((pixel[1] << ParamPrecision) - zR)) >> AlphaPrecision;
             zG += (alpha * ((pixel[2] << ParamPrecision) - zG)) >> AlphaPrecision;
             zB += (alpha * ((pixel[3] << ParamPrecision) - zB)) >> AlphaPrecision;
-            
+
             pixel[0] = (uint8) (zA >> ParamPrecision);
             pixel[1] = (uint8) (zR >> ParamPrecision);
             pixel[2] = (uint8) (zG >> ParamPrecision);
             pixel[3] = (uint8) (zB >> ParamPrecision);
         }
-        
+
         /**
          * Performs a blur operation on the internal {@link Cairo.Surface}, using a
          * gaussian blurring algorithm. This method is very slow, albeit producing
@@ -477,31 +477,31 @@ namespace Granite.Drawing {
          * @param radius the blur radius
          */
         public void gaussian_blur (int radius) {
-        
+
             var gausswidth = radius * 2 + 1;
             var kernel = build_gaussian_kernel (gausswidth);
-            
+
             var width = this.width;
             var height = this.height;
-            
+
             var original = new ImageSurface (Format.ARGB32, width, height);
             var cr = new Cairo.Context (original);
-            
+
             cr.set_operator (Operator.SOURCE);
             cr.set_source_surface (surface, 0, 0);
             cr.paint ();
-            
+
             uint8 *src = original.get_data ();
-            
+
             var size = height * original.get_stride ();
-            
+
             var abuffer = new double[size];
             var bbuffer = new double[size];
-            
+
             // Copy image to double[] for faster horizontal pass
             for (var i = 0; i < size; i++)
                 abuffer[i] = (double) src[i];
-            
+
             // Precompute horizontal shifts
             var shiftar = new int[int.max (width, height), gausswidth];
             for (var x = 0; x < width; x++)
@@ -512,7 +512,7 @@ namespace Granite.Drawing {
                     else
                         shiftar[x, k] = shift * 4;
                 }
-            
+
             try {
                 // Horizontal Pass
                 var th = new Thread<void*>.try (null, () => {
@@ -522,10 +522,10 @@ namespace Granite.Drawing {
 
                 gaussian_blur_horizontal (abuffer, bbuffer, kernel, gausswidth, width, height, height / 2, height, shiftar);
                 th.join ();
-                
+
                 // Clear buffer
                 memset (abuffer, 0, sizeof(double) * size);
-                
+
                 // Precompute vertical shifts
                 shiftar = new int[int.max (width, height), gausswidth];
                 for (var y = 0; y < height; y++)
@@ -536,7 +536,7 @@ namespace Granite.Drawing {
                         else
                             shiftar[y, k] = shift * width * 4;
                     }
-                
+
                 // Vertical Pass
                 var th2 = new Thread<void*>.try (null, () => {
                     gaussian_blur_vertical (bbuffer, abuffer, kernel, gausswidth, width, height, 0, width / 2, shiftar);
@@ -548,13 +548,13 @@ namespace Granite.Drawing {
             } catch (Error err) {
                 message (err.message);
             }
-            
+
             // Save blurred image to original uint8[]
             for (var i = 0; i < size; i++)
                 src[i] = (uint8) abuffer[i];
-            
+
             original.mark_dirty ();
-            
+
             context.set_operator (Operator.SOURCE);
             context.set_source_surface (original, 0, 0);
             context.paint ();
@@ -562,74 +562,74 @@ namespace Granite.Drawing {
         }
 
         void gaussian_blur_horizontal (double* src, double* dest, double* kernel, int gausswidth, int width, int height, int startRow, int endRow, int[,] shift) {
-        
+
             uint32 cur_pixel = startRow * width * 4;
-            
+
             for (var y = startRow; y < endRow; y++) {
                 for (var x = 0; x < width; x++) {
                     for (var k = 0; k < gausswidth; k++) {
                         var source = cur_pixel + shift[x, k];
-                        
+
                         dest[cur_pixel + 0] += src[source + 0] * kernel[k];
                         dest[cur_pixel + 1] += src[source + 1] * kernel[k];
                         dest[cur_pixel + 2] += src[source + 2] * kernel[k];
                         dest[cur_pixel + 3] += src[source + 3] * kernel[k];
                     }
-                    
+
                     cur_pixel += 4;
                 }
             }
         }
-        
+
         void gaussian_blur_vertical (double* src, double* dest, double* kernel, int gausswidth, int width, int height, int startCol, int endCol, int[,] shift) {
-        
+
             uint32 cur_pixel = startCol * 4;
-            
+
             for (var y = 0; y < height; y++) {
                 for (var x = startCol; x < endCol; x++) {
                     for (var k = 0; k < gausswidth; k++) {
                         var source = cur_pixel + shift[y, k];
-                        
+
                         dest[cur_pixel + 0] += src[source + 0] * kernel[k];
                         dest[cur_pixel + 1] += src[source + 1] * kernel[k];
                         dest[cur_pixel + 2] += src[source + 2] * kernel[k];
                         dest[cur_pixel + 3] += src[source + 3] * kernel[k];
                     }
-                    
+
                     cur_pixel += 4;
                 }
                 cur_pixel += (width - endCol + startCol) * 4;
             }
         }
-        
+
         static double[] build_gaussian_kernel (int gausswidth) requires (gausswidth % 2 == 1) {
-            
+
             var kernel = new double[gausswidth];
-            
+
             // Maximum value of curve
             var sd = 255.0;
-            
+
             // width of curve
             var range = gausswidth;
-            
+
             // Average value of curve
             var mean = range / sd;
-            
+
             for (var i = 0; i < gausswidth / 2 + 1; i++)
                 kernel[gausswidth - i - 1] = kernel[i] = Math.pow (Math.sin (((i + 1) * (Math.PI / 2) - mean) / range), 2) * sd;
-            
+
             // normalize the values
             var gaussSum = 0.0;
-            foreach (var d in kernel)            
+            foreach (var d in kernel)
                 gaussSum += d;
-            
+
             for (var i = 0; i < kernel.length; i++)
                 kernel[i] = kernel[i] / gaussSum;
-            
+
             return kernel;
         }
-        
+
     }
-    
+
 }
 

--- a/lib/Drawing/BufferSurface.vala
+++ b/lib/Drawing/BufferSurface.vala
@@ -1,5 +1,6 @@
 /*
- *  Copyright (C) 2011-2013 Robert Dyer,
+ *  Copyright (C) 2019 elementary, Inc. (https://elementary.io)
+ *                2011-2013 Robert Dyer,
  *                          Rico Tzschichholz <ricotz@ubuntu.com>
  *
  *  This program or library is free software; you can redistribute it
@@ -413,7 +414,16 @@ namespace Granite.Drawing {
             context.set_operator (Operator.OVER);
         }
 
-        void exponential_blur_columns (uint8* pixels, int width, int height, int startCol, int endCol, int startY, int endY, int alpha) {
+        void exponential_blur_columns (
+            uint8* pixels,
+            int width,
+            int height,
+            int startCol,
+            int endCol,
+            int startY,
+            int endY,
+            int alpha
+        ) {
 
             for (var columnIndex = startCol; columnIndex < endCol; columnIndex++) {
                 // blur columns
@@ -434,7 +444,16 @@ namespace Granite.Drawing {
             }
         }
 
-        void exponential_blur_rows (uint8* pixels, int width, int height, int startRow, int endRow, int startX, int endX, int alpha) {
+        void exponential_blur_rows (
+            uint8* pixels,
+            int width,
+            int height,
+            int startRow,
+            int endRow,
+            int startX,
+            int endX,
+            int alpha
+        ) {
 
             for (var rowIndex = startRow; rowIndex < endRow; rowIndex++) {
                 // Get a pointer to our current row
@@ -455,7 +474,14 @@ namespace Granite.Drawing {
             }
         }
 
-        private static inline void exponential_blur_inner (uint8* pixel, ref int zA, ref int zR, ref int zG, ref int zB, int alpha) {
+        private static inline void exponential_blur_inner (
+            uint8* pixel,
+            ref int zA,
+            ref int zR,
+            ref int zG,
+            ref int zB,
+            int alpha
+        ) {
 
             zA += (alpha * ((pixel[0] << ParamPrecision) - zA)) >> AlphaPrecision;
             zR += (alpha * ((pixel[1] << ParamPrecision) - zR)) >> AlphaPrecision;
@@ -516,11 +542,31 @@ namespace Granite.Drawing {
             try {
                 // Horizontal Pass
                 var th = new Thread<void*>.try (null, () => {
-                    gaussian_blur_horizontal (abuffer, bbuffer, kernel, gausswidth, width, height, 0, height / 2, shiftar);
+                    gaussian_blur_horizontal (
+                        abuffer,
+                        bbuffer,
+                        kernel,
+                        gausswidth,
+                        width,
+                        height,
+                        0,
+                        height / 2,
+                        shiftar
+                    );
                     return null;
                 });
 
-                gaussian_blur_horizontal (abuffer, bbuffer, kernel, gausswidth, width, height, height / 2, height, shiftar);
+                gaussian_blur_horizontal (
+                    abuffer,
+                    bbuffer,
+                    kernel,
+                    gausswidth,
+                    width,
+                    height,
+                    height / 2,
+                    height,
+                    shiftar
+                );
                 th.join ();
 
                 // Clear buffer
@@ -561,7 +607,17 @@ namespace Granite.Drawing {
             context.set_operator (Operator.OVER);
         }
 
-        void gaussian_blur_horizontal (double* src, double* dest, double* kernel, int gausswidth, int width, int height, int startRow, int endRow, int[,] shift) {
+        void gaussian_blur_horizontal (
+            double* src,
+            double* dest,
+            double* kernel,
+            int gausswidth,
+            int width,
+            int height,
+            int startRow,
+            int endRow,
+            int[,] shift
+        ) {
 
             uint32 cur_pixel = startRow * width * 4;
 
@@ -581,7 +637,17 @@ namespace Granite.Drawing {
             }
         }
 
-        void gaussian_blur_vertical (double* src, double* dest, double* kernel, int gausswidth, int width, int height, int startCol, int endCol, int[,] shift) {
+        void gaussian_blur_vertical (
+            double* src,
+            double* dest,
+            double* kernel,
+            int gausswidth,
+            int width,
+            int height,
+            int startCol,
+            int endCol,
+            int[,] shift
+        ) {
 
             uint32 cur_pixel = startCol * 4;
 
@@ -615,8 +681,11 @@ namespace Granite.Drawing {
             // Average value of curve
             var mean = range / sd;
 
-            for (var i = 0; i < gausswidth / 2 + 1; i++)
-                kernel[gausswidth - i - 1] = kernel[i] = Math.pow (Math.sin (((i + 1) * (Math.PI / 2) - mean) / range), 2) * sd;
+            for (var i = 0; i < gausswidth / 2 + 1; i++) {
+                kernel[gausswidth - i - 1] = kernel[i] = Math.pow (
+                    Math.sin (((i + 1) * (Math.PI / 2) - mean) / range), 2
+                ) * sd;
+            }
 
             // normalize the values
             var gaussSum = 0.0;
@@ -632,4 +701,3 @@ namespace Granite.Drawing {
     }
 
 }
-

--- a/lib/Drawing/BufferSurface.vala
+++ b/lib/Drawing/BufferSurface.vala
@@ -23,13 +23,11 @@ using Cairo;
 using Posix;
 
 namespace Granite.Drawing {
-
     /**
      * A buffer containing an internal Cairo-usable surface and context, designed
      * for usage with large, rarely updated draw operations.
      */
     public class BufferSurface : GLib.Object {
-
         private Surface _surface;
         /**
          * The {@link Cairo.Surface} which will store the results of all drawing operations
@@ -37,8 +35,10 @@ namespace Granite.Drawing {
          */
         public Surface surface {
             get {
-                if (_surface == null)
+                if (_surface == null) {
                     _surface = new ImageSurface (Format.ARGB32, width, height);
+                }
+
                 return _surface;
             }
             private set { _surface = value; }
@@ -60,8 +60,10 @@ namespace Granite.Drawing {
          */
         public Cairo.Context context {
             get {
-                if (_context == null)
+                if (_context == null) {
                     _context = new Cairo.Context (surface);
+                }
+
                 return _context;
             }
         }
@@ -73,7 +75,6 @@ namespace Granite.Drawing {
          * @param height the height of the {@link Granite.Drawing.BufferSurface}, in pixels
          */
         public BufferSurface (int width, int height) requires (width >= 0 && height >= 0) {
-
             this.width = width;
             this.height = height;
         }
@@ -87,7 +88,6 @@ namespace Granite.Drawing {
          * @param model the {@link Cairo.Surface} to use as a model for the internal {@link Cairo.Surface}
          */
         public BufferSurface.with_surface (int width, int height, Surface model) requires (model != null) {
-
             this (width, height);
             surface = new Surface.similar (model, Content.COLOR_ALPHA, width, height);
         }
@@ -101,7 +101,6 @@ namespace Granite.Drawing {
          * @param model the {@link Granite.Drawing.BufferSurface} to use as a model for the internal {@link Cairo.Surface}
          */
         public BufferSurface.with_buffer_surface (int width, int height, BufferSurface model) requires (model != null) {
-
             this (width, height);
             surface = new Surface.similar (model.surface, Content.COLOR_ALPHA, width, height);
         }
@@ -110,7 +109,6 @@ namespace Granite.Drawing {
          * Clears the internal {@link Cairo.Surface}, making all pixels fully transparent.
          */
         public void clear () {
-
             context.save ();
 
             _context.set_source_rgba (0, 0, 0, 0);
@@ -126,7 +124,6 @@ namespace Granite.Drawing {
          * @return the {@link Gdk.Pixbuf}
          */
         public Gdk.Pixbuf load_to_pixbuf () {
-
             var image_surface = new ImageSurface (Format.ARGB32, width, height);
             var cr = new Cairo.Context (image_surface);
 
@@ -178,7 +175,6 @@ namespace Granite.Drawing {
          * @return the {@link Granite.Drawing.Color} with the averaged color
          */
         public Drawing.Color average_color () {
-
             var b_total = 0.0;
             var g_total = 0.0;
             var r_total = 0.0;
@@ -231,16 +227,17 @@ namespace Granite.Drawing {
          * @param process_count the number of times to perform the operation
          */
         public void fast_blur (int radius, int process_count = 1) {
-
-            if (radius < 1 || process_count < 1)
+            if (radius < 1 || process_count < 1) {
                 return;
+            }
 
             var w = width;
             var h = height;
             var channels = 4;
 
-            if (radius > w - 1 || radius > h - 1)
+            if (radius > w - 1 || radius > h - 1) {
                 return;
+            }
 
             var original = new ImageSurface (Format.ARGB32, w, h);
             var cr = new Cairo.Context (original);
@@ -257,8 +254,10 @@ namespace Granite.Drawing {
 
             var div = 2 * radius + 1;
             var dv = new uint8[256 * div];
-            for (var i = 0; i < dv.length; i++)
+
+            for (var i = 0; i < dv.length; i++) {
                 dv[i] = (uint8) (i / div);
+            }
 
             while (process_count-- > 0) {
                 for (var x = 0; x < w; x++) {
@@ -369,9 +368,9 @@ namespace Granite.Drawing {
          * @param radius the blur radius
          */
         public void exponential_blur (int radius) {
-
-            if (radius < 1)
+            if (radius < 1) {
                 return;
+            }
 
             var alpha = (int) ((1 << ALPHA_PRECISION) * (1.0 - Math.exp (-2.3 / (radius + 1.0))));
             var height = this.height;
@@ -426,7 +425,6 @@ namespace Granite.Drawing {
             int end_y,
             int alpha
         ) {
-
             for (var column_index = start_col; column_index < end_col; column_index++) {
                 // blur columns
                 uint8 *column = pixels + column_index * 4;
@@ -437,12 +435,14 @@ namespace Granite.Drawing {
                 var z_blue = column[3] << PARAM_PRECISION;
 
                 // Top to Bottom
-                for (var index = width * (start_y + 1); index < (end_y - 1) * width; index += width)
+                for (var index = width * (start_y + 1); index < (end_y - 1) * width; index += width) {
                     exponential_blur_inner (&column[index * 4], ref z_alpha, ref z_red, ref z_green, ref z_blue, alpha);
+                }
 
                 // Bottom to Top
-                for (var index = (end_y - 2) * width; index >= start_y; index -= width)
+                for (var index = (end_y - 2) * width; index >= start_y; index -= width) {
                     exponential_blur_inner (&column[index * 4], ref z_alpha, ref z_red, ref z_green, ref z_blue, alpha);
+                }
             }
         }
 
@@ -456,7 +456,6 @@ namespace Granite.Drawing {
             int end_x,
             int alpha
         ) {
-
             for (var row_index = start_row; row_index < end_row; row_index++) {
                 // Get a pointer to our current row
                 uint8* row = pixels + row_index * width * 4;
@@ -484,7 +483,6 @@ namespace Granite.Drawing {
             ref int z_blue,
             int alpha
         ) {
-
             z_alpha += (alpha * ((pixel[0] << PARAM_PRECISION) - z_alpha)) >> ALPHA_PRECISION;
             z_red += (alpha * ((pixel[1] << PARAM_PRECISION) - z_red)) >> ALPHA_PRECISION;
             z_green += (alpha * ((pixel[2] << PARAM_PRECISION) - z_green)) >> ALPHA_PRECISION;
@@ -505,7 +503,6 @@ namespace Granite.Drawing {
          * @param radius the blur radius
          */
         public void gaussian_blur (int radius) {
-
             var gauss_width = radius * 2 + 1;
             var kernel = build_gaussian_kernel (gauss_width);
 
@@ -527,8 +524,9 @@ namespace Granite.Drawing {
             var buffer_b = new double[size];
 
             // Copy image to double[] for faster horizontal pass
-            for (var i = 0; i < size; i++)
+            for (var i = 0; i < size; i++) {
                 buffer_a[i] = (double) src[i];
+            }
 
             // Precompute horizontal shifts
             var shiftar = new int[int.max (width, height), gauss_width];
@@ -618,8 +616,9 @@ namespace Granite.Drawing {
             }
 
             // Save blurred image to original uint8[]
-            for (var i = 0; i < size; i++)
+            for (var i = 0; i < size; i++) {
                 src[i] = (uint8) buffer_a[i];
+            }
 
             original.mark_dirty ();
 
@@ -640,7 +639,6 @@ namespace Granite.Drawing {
             int end_row,
             int[,] shift
         ) {
-
             uint32 cur_pixel = start_row * width * 4;
 
             for (var y = start_row; y < end_row; y++) {
@@ -670,7 +668,6 @@ namespace Granite.Drawing {
             int end_col,
             int[,] shift
         ) {
-
             uint32 cur_pixel = start_col * 4;
 
             for (var y = 0; y < height; y++) {
@@ -691,7 +688,6 @@ namespace Granite.Drawing {
         }
 
         static double[] build_gaussian_kernel (int gauss_width) requires (gauss_width % 2 == 1) {
-
             var kernel = new double[gauss_width];
 
             // Maximum value of curve
@@ -711,15 +707,16 @@ namespace Granite.Drawing {
 
             // normalize the values
             var gauss_sum = 0.0;
-            foreach (var d in kernel)
-                gauss_sum += d;
 
-            for (var i = 0; i < kernel.length; i++)
+            foreach (var d in kernel) {
+                gauss_sum += d;
+            }
+
+            for (var i = 0; i < kernel.length; i++) {
                 kernel[i] = kernel[i] / gauss_sum;
+            }
 
             return kernel;
         }
-
     }
-
 }

--- a/lib/Drawing/BufferSurface.vala
+++ b/lib/Drawing/BufferSurface.vala
@@ -252,8 +252,8 @@ namespace Granite.Drawing {
             uint8 *pixels = original.get_data ();
             var buffer = new uint8[w * h * channels];
 
-            var vmin = new int[int.max (w, h)];
-            var vmax = new int[int.max (w, h)];
+            var v_min = new int[int.max (w, h)];
+            var v_max = new int[int.max (w, h)];
 
             var div = 2 * radius + 1;
             var dv = new uint8[256 * div];
@@ -262,25 +262,25 @@ namespace Granite.Drawing {
 
             while (process_count-- > 0) {
                 for (var x = 0; x < w; x++) {
-                    vmin[x] = int.min (x + radius + 1, w - 1);
-                    vmax[x] = int.max (x - radius, 0);
+                    v_min[x] = int.min (x + radius + 1, w - 1);
+                    v_max[x] = int.max (x - radius, 0);
                 }
 
                 for (var y = 0; y < h; y++) {
-                    var asum = 0, rsum = 0, gsum = 0, bsum = 0;
+                    var a_sum = 0, r_sum = 0, g_sum = 0, b_sum = 0;
 
                     uint32 cur_pixel = y * w * channels;
 
-                    asum += radius * pixels[cur_pixel + 0];
-                    rsum += radius * pixels[cur_pixel + 1];
-                    gsum += radius * pixels[cur_pixel + 2];
-                    bsum += radius * pixels[cur_pixel + 3];
+                    a_sum += radius * pixels[cur_pixel + 0];
+                    r_sum += radius * pixels[cur_pixel + 1];
+                    g_sum += radius * pixels[cur_pixel + 2];
+                    b_sum += radius * pixels[cur_pixel + 3];
 
                     for (var i = 0; i <= radius; i++) {
-                        asum += pixels[cur_pixel + 0];
-                        rsum += pixels[cur_pixel + 1];
-                        gsum += pixels[cur_pixel + 2];
-                        bsum += pixels[cur_pixel + 3];
+                        a_sum += pixels[cur_pixel + 0];
+                        r_sum += pixels[cur_pixel + 1];
+                        g_sum += pixels[cur_pixel + 2];
+                        b_sum += pixels[cur_pixel + 3];
 
                         cur_pixel += channels;
                     }
@@ -288,43 +288,43 @@ namespace Granite.Drawing {
                     cur_pixel = y * w * channels;
 
                     for (var x = 0; x < w; x++) {
-                        uint32 p1 = (y * w + vmin[x]) * channels;
-                        uint32 p2 = (y * w + vmax[x]) * channels;
+                        uint32 p1 = (y * w + v_min[x]) * channels;
+                        uint32 p2 = (y * w + v_max[x]) * channels;
 
-                        buffer[cur_pixel + 0] = dv[asum];
-                        buffer[cur_pixel + 1] = dv[rsum];
-                        buffer[cur_pixel + 2] = dv[gsum];
-                        buffer[cur_pixel + 3] = dv[bsum];
+                        buffer[cur_pixel + 0] = dv[a_sum];
+                        buffer[cur_pixel + 1] = dv[r_sum];
+                        buffer[cur_pixel + 2] = dv[g_sum];
+                        buffer[cur_pixel + 3] = dv[b_sum];
 
-                        asum += pixels[p1 + 0] - pixels[p2 + 0];
-                        rsum += pixels[p1 + 1] - pixels[p2 + 1];
-                        gsum += pixels[p1 + 2] - pixels[p2 + 2];
-                        bsum += pixels[p1 + 3] - pixels[p2 + 3];
+                        a_sum += pixels[p1 + 0] - pixels[p2 + 0];
+                        r_sum += pixels[p1 + 1] - pixels[p2 + 1];
+                        g_sum += pixels[p1 + 2] - pixels[p2 + 2];
+                        b_sum += pixels[p1 + 3] - pixels[p2 + 3];
 
                         cur_pixel += channels;
                     }
                 }
 
                 for (var y = 0; y < h; y++) {
-                    vmin[y] = int.min (y + radius + 1, h - 1) * w;
-                    vmax[y] = int.max (y - radius, 0) * w;
+                    v_min[y] = int.min (y + radius + 1, h - 1) * w;
+                    v_max[y] = int.max (y - radius, 0) * w;
                 }
 
                 for (var x = 0; x < w; x++) {
-                    var asum = 0, rsum = 0, gsum = 0, bsum = 0;
+                    var a_sum = 0, r_sum = 0, g_sum = 0, b_sum = 0;
 
                     uint32 cur_pixel = x * channels;
 
-                    asum += radius * buffer[cur_pixel + 0];
-                    rsum += radius * buffer[cur_pixel + 1];
-                    gsum += radius * buffer[cur_pixel + 2];
-                    bsum += radius * buffer[cur_pixel + 3];
+                    a_sum += radius * buffer[cur_pixel + 0];
+                    r_sum += radius * buffer[cur_pixel + 1];
+                    g_sum += radius * buffer[cur_pixel + 2];
+                    b_sum += radius * buffer[cur_pixel + 3];
 
                     for (var i = 0; i <= radius; i++) {
-                        asum += buffer[cur_pixel + 0];
-                        rsum += buffer[cur_pixel + 1];
-                        gsum += buffer[cur_pixel + 2];
-                        bsum += buffer[cur_pixel + 3];
+                        a_sum += buffer[cur_pixel + 0];
+                        r_sum += buffer[cur_pixel + 1];
+                        g_sum += buffer[cur_pixel + 2];
+                        b_sum += buffer[cur_pixel + 3];
 
                         cur_pixel += w * channels;
                     }
@@ -332,18 +332,18 @@ namespace Granite.Drawing {
                     cur_pixel = x * channels;
 
                     for (var y = 0; y < h; y++) {
-                        uint32 p1 = (x + vmin[y]) * channels;
-                        uint32 p2 = (x + vmax[y]) * channels;
+                        uint32 p1 = (x + v_min[y]) * channels;
+                        uint32 p2 = (x + v_max[y]) * channels;
 
-                        pixels[cur_pixel + 0] = dv[asum];
-                        pixels[cur_pixel + 1] = dv[rsum];
-                        pixels[cur_pixel + 2] = dv[gsum];
-                        pixels[cur_pixel + 3] = dv[bsum];
+                        pixels[cur_pixel + 0] = dv[a_sum];
+                        pixels[cur_pixel + 1] = dv[r_sum];
+                        pixels[cur_pixel + 2] = dv[g_sum];
+                        pixels[cur_pixel + 3] = dv[b_sum];
 
-                        asum += buffer[p1 + 0] - buffer[p2 + 0];
-                        rsum += buffer[p1 + 1] - buffer[p2 + 1];
-                        gsum += buffer[p1 + 2] - buffer[p2 + 2];
-                        bsum += buffer[p1 + 3] - buffer[p2 + 3];
+                        a_sum += buffer[p1 + 0] - buffer[p2 + 0];
+                        r_sum += buffer[p1 + 1] - buffer[p2 + 1];
+                        g_sum += buffer[p1 + 2] - buffer[p2 + 2];
+                        b_sum += buffer[p1 + 3] - buffer[p2 + 3];
 
                         cur_pixel += w * channels;
                     }

--- a/lib/Drawing/BufferSurface.vala
+++ b/lib/Drawing/BufferSurface.vala
@@ -570,7 +570,7 @@ namespace Granite.Drawing {
                 th.join ();
 
                 // Clear buffer
-                memset (abuffer, 0, sizeof(double) * size);
+                memset (abuffer, 0, sizeof (double) * size);
 
                 // Precompute vertical shifts
                 shiftar = new int[int.max (width, height), gausswidth];


### PR DESCRIPTION
A ton of end-of-line whitespace changes, so probably best viewed with whitespace changes off. With variable name changes, we need to make sure they were all internal and don't affect API.