### PR TITLE
Abstract Settings Pages: Lint

### DIFF
--- a/lib/Widgets/AbstractSettingsPage.vala
+++ b/lib/Widgets/AbstractSettingsPage.vala
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2017 elementary LLC. (https://elementary.io)
+* Copyright (c) 2017–2019 elementary, Inc. (https://elementary.io)
 *
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU Lesser General Public License as published by
@@ -62,7 +62,7 @@ public abstract class Granite.SettingsPage : Gtk.ScrolledWindow {
     public string? icon_name {
         get {
             return _icon_name;
-        } 
+        }
         construct set {
             _icon_name = value;
         }
@@ -74,7 +74,7 @@ public abstract class Granite.SettingsPage : Gtk.ScrolledWindow {
     public string title {
         get {
             return _title;
-        } 
+        }
         construct set {
             _title = value;
         }

--- a/lib/Widgets/AbstractSimpleSettingsPage.vala
+++ b/lib/Widgets/AbstractSimpleSettingsPage.vala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2017-2019 elementary, Inc. (https://elementary.io)
+* Copyright 2017–2019 elementary, Inc. (https://elementary.io)
 *
 * This program is free software; you can redistribute it and/or
 * modify it under the terms of the GNU General Public
@@ -55,7 +55,7 @@ public abstract class Granite.SimpleSettingsPage : Granite.SettingsPage {
     public string description {
         get {
             return _description;
-        } 
+        }
         construct set {
             if (description_label != null) {
                 description_label.label = value;
@@ -71,7 +71,7 @@ public abstract class Granite.SimpleSettingsPage : Granite.SettingsPage {
     public new string icon_name {
         get {
             return _icon_name;
-        } 
+        }
         construct set {
             if (header_icon != null) {
                 header_icon.icon_name = value;
@@ -87,7 +87,7 @@ public abstract class Granite.SimpleSettingsPage : Granite.SettingsPage {
     public new string title {
         get {
             return _title;
-        } 
+        }
         construct set {
             if (title_label != null) {
                 title_label.label = value;


### PR DESCRIPTION
two-in-one since they're so small and just trailing whitespace