### PR TITLE
Expose tab label tooltip

### DIFF
--- a/data/granite.appdata.xml.in
+++ b/data/granite.appdata.xml.in
@@ -10,6 +10,14 @@
     <p>A companion library for GTK and GLib that provides complex widgets and convenience methods designed for use in apps built for elementary OS.</p>
   </description>
   <releases>
+    <release version="5.4.1" date="2020-05-29" urgency="medium">
+      <description>
+        <p>Improvements:</p>
+        <ul>
+          <li>Make tab tooltips of DynamicNotebook settable</li>
+        </ul>
+      </description>
+    </release>
     <release version="5.4.0" date="2020-04-29" urgency="medium">
       <description>
         <p>New features:</p>

--- a/demo/Views/DynamicNotebookView.vala
+++ b/demo/Views/DynamicNotebookView.vala
@@ -38,6 +38,7 @@ public class DynamicNotebookView : Gtk.Grid {
                 new ThemedIcon ("mail-mark-important-symbolic"),
                 page
             );
+            tab.tooltip = "Customizable tooltip %d".printf (i);
             notebook.insert_tab (tab, i - 1);
         }
 
@@ -46,6 +47,7 @@ public class DynamicNotebookView : Gtk.Grid {
             var tab = new Granite.Widgets.Tab (
                 "Tab %d".printf (i), new ThemedIcon ("mail-mark-important-symbolic"), page
             );
+            tab.tooltip = "Customizable tooltip %d".printf (i);
             notebook.insert_tab (tab, i - 1);
             i++;
         });

--- a/lib/Widgets/DynamicNotebook.vala
+++ b/lib/Widgets/DynamicNotebook.vala
@@ -75,6 +75,9 @@ namespace Granite.Widgets {
             }
         }
 
+        /**
+         * The (plain) text that will be shown in a tooltip when the tab is hovered.
+         **/
         public string tooltip {
             set {
                 _label.set_tooltip_text (value);

--- a/lib/Widgets/DynamicNotebook.vala
+++ b/lib/Widgets/DynamicNotebook.vala
@@ -75,6 +75,12 @@ namespace Granite.Widgets {
             }
         }
 
+        public string tooltip {
+            set {
+                _label.set_tooltip_text (value);
+            }
+        }
+
         private bool _pinned = false;
         public bool pinned {
             get { return _pinned; }


### PR DESCRIPTION
Allow apps to set a tooltip with additional information rather than just repeating information that is already visible in the tab label (although the label could be ellipsized)