### PR TITLE
build: add gsettings-desktop-schemas to pkgconfig Requires

### DIFF
--- a/lib/meson.build
+++ b/lib/meson.build
@@ -123,11 +123,17 @@ libgranite_dep = declare_dependency(
     include_directories: [include_directories('.')],
 )
 
+gsettings_desktop_schemas_dep = [
+    dependency('gsettings-desktop-schemas', version: '>= 3.27.1')
+]
+
+pc_deps = libgranite_deps + gsettings_desktop_schemas_dep
+
 # generate pkgconfig file
 granite_pc = pkgconfig.generate(
     libgranite,
     name: 'granite',
-    requires: libgranite_deps,
+    requires: pc_deps,
     subdirs: ['granite'],
     description: 'elementary\'s Application Framework',
     version: meson.project_version(),


### PR DESCRIPTION
While there's code in lib/Services/System.vala#history_is_enabled, which will return
if we can't find org.gnome.desktop.privacy, it still seems like we require this, and
we need to make sure applicaitons that use granite have it installed.
Otherwise, methods like is_clock_format_12h will crash the application.