### PR TITLE
DynamicNotebook: Get rid of the big spinner

### DIFF
--- a/lib/Widgets/DynamicNotebook.vala
+++ b/lib/Widgets/DynamicNotebook.vala
@@ -789,11 +789,6 @@ namespace Granite.Widgets {
             notebook.show_border = false;
             _tab_bar_behavior = TabBarBehavior.ALWAYS;
 
-            draw.connect ( (ctx) => {
-                get_style_context ().render_activity (ctx, 0, 0, get_allocated_width (), 27);
-                return false;
-            });
-
             add (notebook);
 
             menu = new Gtk.Menu ();


### PR DESCRIPTION
Any idea what this was for?

Seems that Tom added it [here](https://github.com/elementary/granite/commit/e7f12f36438ded8cfb973c84cf29b419ccc8a3ff) 8 years ago. No idea what it's supposed to do. Seems like nothing :p 