### PR TITLE
Add new Granite.Avatar

### DIFF
--- a/demo/Views/AvatarView.vala
+++ b/demo/Views/AvatarView.vala
@@ -20,24 +20,24 @@
 
 public class AvatarView : Gtk.Grid {
     construct {
-        var username = GLib.Environment.get_user_name ();
-        var iconfile = @"/var/lib/AccountsService/icons/$username";
+        var realname = GLib.Environment.get_real_name ();
+        var iconfile = "/var/lib/AccountsService/icons/%s".printf (GLib.Environment.get_user_name ());
 
-        var avatar_menu = new Granite.Widgets.Avatar.from_file (iconfile, 16);
+        var avatar_menu = new Granite.Avatar (realname, 24, iconfile);
 
-        var avatar_large_toolbar = new Granite.Widgets.Avatar.from_file (iconfile, 24);
+        var avatar_large_toolbar = new Granite.Avatar (realname, 32, iconfile);
 
-        var avatar_dnd = new Granite.Widgets.Avatar.from_file (iconfile, 32);
+        var avatar_dnd = new Granite.Avatar (realname, 48, iconfile);
 
-        var avatar_dialog = new Granite.Widgets.Avatar.from_file (iconfile, 48);
+        var avatar_dialog = new Granite.Avatar (realname, 64, iconfile);
 
-        var avatar_default_menu = new Granite.Widgets.Avatar.with_default_icon (16);
+        var avatar_default_menu = new Granite.Avatar (realname, 24);
 
-        var avatar_default_large_toolbar = new Granite.Widgets.Avatar.with_default_icon (24);
+        var avatar_default_large_toolbar = new Granite.Avatar (realname, 32);
 
-        var avatar_default_dnd = new Granite.Widgets.Avatar.with_default_icon (32);
+        var avatar_default_dnd = new Granite.Avatar (realname, 48);
 
-        var avatar_default_dialog = new Granite.Widgets.Avatar.with_default_icon (48);
+        var avatar_default_dialog = new Granite.Avatar (realname, 64);
 
         column_spacing = 12;
         row_spacing = 6;
@@ -45,15 +45,15 @@ public class AvatarView : Gtk.Grid {
         valign = Gtk.Align.CENTER;
         attach (avatar_menu, 0, 0, 1, 1);
         attach (avatar_default_menu, 0, 1, 1, 1);
-        attach (new Gtk.Label ("16px"), 0, 2, 1, 1);
+        attach (new Gtk.Label ("24px"), 0, 2, 1, 1);
         attach (avatar_large_toolbar, 1, 0, 1, 1);
         attach (avatar_default_large_toolbar, 1, 1, 1, 1);
-        attach (new Gtk.Label ("24px"), 1, 2, 1, 1);
+        attach (new Gtk.Label ("32px"), 1, 2, 1, 1);
         attach (avatar_dnd, 2, 0, 1, 1);
         attach (avatar_default_dnd, 2, 1, 1, 1);
-        attach (new Gtk.Label ("32px"), 2, 2, 1, 1);
+        attach (new Gtk.Label ("48px"), 2, 2, 1, 1);
         attach (avatar_dialog, 3, 0, 1, 1);
         attach (avatar_default_dialog, 3, 1, 1, 1);
-        attach (new Gtk.Label ("48px"), 3, 2, 1, 1);
+        attach (new Gtk.Label ("64px"), 3, 2, 1, 1);
     }
 }

--- a/lib/Widgets/Avatar.vala
+++ b/lib/Widgets/Avatar.vala
@@ -51,28 +51,6 @@ public class Granite.Avatar : Gtk.Grid {
         );
     }
 
-    /**
-     * Creates a new Avatar from a LibFolks Individual and the specified pixel size
-     *
-     * @param individual The {@link Folks.Individual } to get display name and avatar information from
-     * @param pixel_size The size in pixels to render the widget at
-     */
-    public Avatar.from_individual (Folks.Individual individual, int pixel_size) {
-        Object (
-            full_name: individual.display_name,
-            pixel_size: pixel_size
-        );
-
-        if (individual.avatar != null) {
-            try {
-                individual.avatar.load (pixel_size, null);
-                icon_file = individual.avatar.to_string ();
-            } catch (Error e) {
-                critical (e.message);
-            }
-        }
-    }
-
     construct {
         set_css_name (Granite.STYLE_CLASS_AVATAR);
 

--- a/lib/Widgets/Avatar.vala
+++ b/lib/Widgets/Avatar.vala
@@ -78,6 +78,7 @@ public class Granite.Avatar : Gtk.Grid {
 
         name_label = new Gtk.Label (get_initials ());
         name_label.halign = name_label.valign = Gtk.Align.CENTER;
+        name_label.use_markup = true;
 
         var overlay_grid = new AvatarOverlay ();
 
@@ -180,7 +181,10 @@ public class Granite.Avatar : Gtk.Grid {
             initials += names[names.length - 1].substring (0, 1).up ();
         }
 
-        return (initials);
+        var font_size = (int) (0.35 * pixel_size);
+        var markup = """<span font="%i">%s</span>""".printf (font_size, initials);
+
+        return (markup);
     }
 
     // We have to do this so Gtk knows we want this specific grid and not all grids

--- a/lib/Widgets/OldAvatar.vala
+++ b/lib/Widgets/OldAvatar.vala
@@ -1,0 +1,190 @@
+/*
+ *  Copyright (C) 2015-2017 Granite Developers (https://launchpad.net/granite)
+ *
+ *  This program or library is free software; you can redistribute it
+ *  and/or modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General
+ *  Public License along with this library; if not, write to the
+ *  Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ *  Boston, MA 02110-1301 USA.
+ *
+ *  Authored by: Felipe Escoto <felescoto95@hotmail.com>, Rico Tzschichholz <ricotz@ubuntu.com>
+ */
+
+/**
+ * The Avatar widget allowes to theme & crop images with css BORDER_RADIUS property in the .avatar class.
+ *
+ * ''Example''<<BR>>
+ * {{{
+ * public class AvatarView : Gtk.Grid {
+ *     construct {
+ *         var username = GLib.Environment.get_user_name ();
+ *         var iconfile = @"/var/lib/AccountsService/icons/$username";
+ *
+ *         var avatar_dialog = new Granite.Widgets.Avatar.from_file (iconfile, 48);
+ *
+ *         var avatar_default_dialog = new Granite.Widgets.Avatar.with_default_icon (48);
+ *
+ *         row_spacing = 6;
+ *         halign = Gtk.Align.CENTER;
+ *         valign = Gtk.Align.CENTER;
+ *         attach (avatar_dialog, 0, 0, 1, 1);
+ *         attach (avatar_default_dialog, 0, 1, 1, 1);
+ *     }
+ * }
+ * }}}
+ */
+public class Granite.Widgets.Avatar : Gtk.EventBox {
+    private const string DEFAULT_ICON = "avatar-default";
+    private const int EXTRA_MARGIN = 4;
+    private bool draw_theme_background = true;
+
+    private bool is_default = false;
+    private string? orig_filename = null;
+    private int? orig_pixel_size = null;
+
+    public Gdk.Pixbuf? pixbuf { get; set; }
+
+    /**
+     * Makes new Avatar widget
+     *
+     */
+    public Avatar () {
+    }
+
+    /**
+    * Creates a new Avatar from the specified pixbuf
+    *
+    * @param pixbuf image to be used
+    */
+    public Avatar.from_pixbuf (Gdk.Pixbuf pixbuf) {
+        Object (pixbuf: pixbuf);
+    }
+
+    /**
+     * Creates a new Avatar from the specified filepath and icon size
+     *
+     * @param filepath image to be used
+     * @param pixel_size to scale the image
+     */
+    public Avatar.from_file (string filepath, int pixel_size) {
+        load_image (filepath, pixel_size);
+        orig_filename = filepath;
+        orig_pixel_size = pixel_size;
+    }
+
+    private void load_image (string filepath, int pixel_size) {
+        try {
+            var size = pixel_size * get_scale_factor ();
+            pixbuf = new Gdk.Pixbuf.from_file_at_size (filepath, size, size);
+        } catch (Error e) {
+            show_default (pixel_size);
+        }
+    }
+
+    /**
+     * Creates a new Avatar with the default icon from theme without applying the css style
+     *
+     * @param pixel_size size of the icon to be loaded
+     */
+    public Avatar.with_default_icon (int pixel_size) {
+        show_default (pixel_size);
+        orig_pixel_size = pixel_size;
+    }
+
+    construct {
+        valign = Gtk.Align.CENTER;
+        halign = Gtk.Align.CENTER;
+        visible_window = false;
+        var style_context = get_style_context ();
+        style_context.add_class (Granite.STYLE_CLASS_AVATAR);
+
+        notify["pixbuf"].connect (refresh_size_request);
+        Gdk.Screen.get_default ().monitors_changed.connect (dpi_change);
+    }
+
+    ~Avatar () {
+        notify["pixbuf"].disconnect (refresh_size_request);
+        Gdk.Screen.get_default ().monitors_changed.disconnect (dpi_change);
+    }
+
+    private void refresh_size_request () {
+        if (pixbuf != null) {
+            var scale_factor = get_scale_factor ();
+            set_size_request (pixbuf.width / scale_factor + EXTRA_MARGIN * 2, pixbuf.height / scale_factor + EXTRA_MARGIN * 2);
+            draw_theme_background = true;
+        } else {
+            set_size_request (0, 0);
+        }
+
+        queue_draw ();
+    }
+
+    private void dpi_change () {
+        if (is_default && orig_pixel_size != null) {
+            show_default (orig_pixel_size);
+        } else {
+            if (orig_filename != null && orig_pixel_size != null) {
+                load_image (orig_filename, orig_pixel_size);
+            }
+        }
+    }
+
+    /**
+     * Load the default avatar icon from theme into the widget without applying the css style
+     *
+     * @param pixel_size size of the icon to be loaded
+     */
+    public void show_default (int pixel_size) {
+        Gtk.IconTheme icon_theme = Gtk.IconTheme.get_default ();
+        try {
+            pixbuf = icon_theme.load_icon_for_scale (DEFAULT_ICON, pixel_size, get_scale_factor (), 0);
+        } catch (Error e) {
+            stderr.printf ("Error setting default avatar icon: %s ", e.message);
+        }
+
+        draw_theme_background = false;
+        is_default = true;
+    }
+
+    public override bool draw (Cairo.Context cr) {
+        if (pixbuf == null) {
+            return base.draw (cr);
+        }
+
+        unowned Gtk.StyleContext style_context = get_style_context ();
+        var width = get_allocated_width () - EXTRA_MARGIN * 2;
+        var height = get_allocated_height () - EXTRA_MARGIN * 2;
+        var scale_factor = get_scale_factor ();
+
+        if (draw_theme_background) {
+            var border_radius = style_context.get_property (Gtk.STYLE_PROPERTY_BORDER_RADIUS, style_context.get_state ()).get_int ();
+            var crop_radius = int.min (width / 2, border_radius * width / 100);
+
+            Granite.Drawing.Utilities.cairo_rounded_rectangle (cr, EXTRA_MARGIN, EXTRA_MARGIN, width, height, crop_radius);
+            cr.save ();
+            cr.scale (1.0 / scale_factor, 1.0 / scale_factor);
+            Gdk.cairo_set_source_pixbuf (cr, pixbuf, EXTRA_MARGIN * scale_factor, EXTRA_MARGIN * scale_factor);
+            cr.fill_preserve ();
+            cr.restore ();
+            style_context.render_background (cr, EXTRA_MARGIN, EXTRA_MARGIN, width, height);
+            style_context.render_frame (cr, EXTRA_MARGIN, EXTRA_MARGIN, width, height);
+
+        } else {
+            cr.save ();
+            cr.scale (1.0 / scale_factor, 1.0 / scale_factor);
+            style_context.render_icon (cr, pixbuf, EXTRA_MARGIN, EXTRA_MARGIN);
+            cr.restore ();
+        }
+
+        return Gdk.EVENT_STOP;
+    }
+}

--- a/lib/Widgets/OldAvatar.vala
+++ b/lib/Widgets/OldAvatar.vala
@@ -42,6 +42,8 @@
  * }
  * }}}
  */
+
+[Version (deprecated = true, deprecated_since = "5.5.0", replacement = "Granite.Avatar")]
 public class Granite.Widgets.Avatar : Gtk.EventBox {
     private const string DEFAULT_ICON = "avatar-default";
     private const int EXTRA_MARGIN = 4;

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -37,6 +37,7 @@ libgranite_sources = files(
     'Widgets/MessageDialog.vala',
     'Widgets/ModeButton.vala',
     'Widgets/ModeSwitch.vala',
+    'Widgets/OldAvatar.vala',
     'Widgets/OverlayBar.vala',
     'Widgets/SeekBar.vala',
     'Widgets/Settings.vala',

--- a/meson.build
+++ b/meson.build
@@ -37,7 +37,6 @@ add_project_arguments(
 )
 
 libgranite_deps = [
-    dependency('folks'),
     dependency('gee-0.8'),
     dependency('gio-2.0', version: '>=' + glib_min_version),
     dependency('gio-unix-2.0', version: '>=' + glib_min_version),

--- a/meson.build
+++ b/meson.build
@@ -37,6 +37,7 @@ add_project_arguments(
 )
 
 libgranite_deps = [
+    dependency('folks'),
     dependency('gee-0.8'),
     dependency('gio-2.0', version: '>=' + glib_min_version),
     dependency('gio-unix-2.0', version: '>=' + glib_min_version),


### PR DESCRIPTION
![Screenshot from 2020-05-27 13 15 39@2x](https://user-images.githubusercontent.com/7277719/83067988-66a77380-a01c-11ea-91fa-b6a83a32be39.png)

This creates a new `Granite.Avatar` and deprecates the old `Granite.Widgets.Avatar`.

Use with https://github.com/elementary/stylesheet/pull/721

Major differences are:
* Two CSS Nodes `avatar` and `avatar-overlay`, which put shadows and highlights in the right place. Finally solving #398 
* Falls back to initials instead of a generic icon
* No internal margins so the widget is the actual size you requested, whether or not it is using the fallback
* Properties are all settable instead of construct-only
* No creation directly from a pixbuf