### PR TITLE
Null check color scheme

### DIFF
--- a/lib/Widgets/Settings.vala
+++ b/lib/Widgets/Settings.vala
@@ -101,7 +101,9 @@ namespace Granite {
 
                 ((GLib.DBusProxy) pantheon_act).g_properties_changed.connect ((changed, invalid) => {
                     var color_scheme = changed.lookup_value ("PrefersColorScheme", new VariantType ("i"));
-                    prefers_color_scheme = (ColorScheme) color_scheme.get_int32 ();
+                    if (color_scheme != null) {
+                        prefers_color_scheme = (ColorScheme) color_scheme.get_int32 ();
+                    }
                 });
             } catch (Error e) {
                 critical (e.message);


### PR DESCRIPTION
Prevents critical errors being logged when a key other than the color scheme key is changed on the interface.