### PR TITLE
accel_to_string: explicitly set backslash string

### DIFF
--- a/lib/Widgets/Utils.vala
+++ b/lib/Widgets/Utils.vala
@@ -131,6 +131,9 @@ public static string accel_to_string (string? accel) {
             ///TRANSLATORS: The Alt key on the right side of the keyboard
             arr += _("Right Alt");
             break;
+        case Gdk.Key.backslash:
+            arr += "\\";
+            break;
         case Gdk.Key.minus:
         case Gdk.Key.KP_Subtract:
             ///TRANSLATORS: This is a non-symbol representation of the "-" key


### PR DESCRIPTION
Fixes #385. Turns out the translation was coming from Gdk, not us.

![Screenshot from 2020-08-25 16-44-39@2x](https://user-images.githubusercontent.com/611168/91235195-46a64f80-e6f2-11ea-88e6-840b1d1436bc.png)
