### PR TITLE
Utils: accel_to_string add Ctrl_L and Ctrl_R

### DIFF
--- a/lib/Widgets/Utils.vala
+++ b/lib/Widgets/Utils.vala
@@ -134,6 +134,14 @@ public static string accel_to_string (string? accel) {
         case Gdk.Key.backslash:
             arr += "\\";
             break;
+        case Gdk.Key.Control_R:
+            ///TRANSLATORS: The Ctrl key on the right side of the keyboard
+            arr += _("Right Ctrl");
+            break;
+        case Gdk.Key.Control_L:
+            ///TRANSLATORS: The Ctrl key on the left side of the keyboard
+            arr += _("Left Ctrl");
+            break;
         case Gdk.Key.minus:
         case Gdk.Key.KP_Subtract:
             ///TRANSLATORS: This is a non-symbol representation of the "-" key


### PR DESCRIPTION
Currently these report as "Control L" and "Control R".

I guess we should decide whether it should be "Left Control" or "Left Ctrl"

Some context:

![Screenshot from 2020-08-31 14 16 58@2x](https://user-images.githubusercontent.com/7277719/91769775-d89bd580-eb94-11ea-9d7a-7fb433e9a907.png)
![Screenshot from 2020-08-31 14 16 44@2x](https://user-images.githubusercontent.com/7277719/91769762-d3d72180-eb94-11ea-9b45-f8be69a0879e.png)
