### PR TITLE
Constants: Add transition durations

### DIFF
--- a/data/granite.appdata.xml.in
+++ b/data/granite.appdata.xml.in
@@ -12,10 +12,10 @@
   <releases>
     <release version="5.5.1" date="2020-08-25" urgency="medium">
       <description>
-        <p>New Style Constants:</p>
+        <p>New Constants:</p>
         <ul>
-          <li>STYLE_CLASS_WARMTH for scales</li>
-          <li>STYLE_CLASS_TEMPERATURE for scales</li>
+          <li>STYLE_CLASS_WARMTH and STYLE_CLASS_TEMPERATURE for scales</li>
+          <li>TRANSITION_DURATION_OPEN and TRANSITION_DURATION_CLOSE for consistent animations</li>
         </ul>
         <p>Other Changes:</p>
         <ul>

--- a/lib/Constants.vala
+++ b/lib/Constants.vala
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2012-2017 elementary LLC. (https://elementary.io)
+ *  Copyright 2012-2020 elementary, Inc. (https://elementary.io)
  *
  *  This program or library is free software; you can redistribute it
  *  and/or modify it under the terms of the GNU Lesser General Public
@@ -149,4 +149,14 @@ namespace Granite {
      * Style class for a temperature scale, a {@link Gtk.Scale} with a "cold" to "hot" color gradient
      */
     public const string STYLE_CLASS_TEMPERATURE = "temperature";
+
+    /**
+     * Transition duration when a widget closes, hides a portion of its content, or exits the screen
+     */
+    public const int TRANSITION_DURATION_CLOSE = 200;
+
+    /**
+     * Transition duration when a widget opens, reveals more content, or enters the screen
+     */
+    public const int TRANSITION_DURATION_OPEN = 250;
 }

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -1,7 +1,7 @@
 libgranite_sources = files(
     'Application.vala',
     'DateTime.vala',
-    'StyleClass.vala',
+    'Constants.vala',
 
     'Drawing/BufferSurface.vala',
     'Drawing/Color.vala',

--- a/po/POTFILES
+++ b/po/POTFILES
@@ -1,6 +1,5 @@
 lib/Application.vala
 lib/DateTime.vala
-lib/StyleClass.vala
 
 lib/Drawing/BufferSurface.vala
 lib/Drawing/Color.vala


### PR DESCRIPTION
Fixes #429 

I opted for only these two constants because it seems the material guidelines only recommend the longer transition durations for things like changing pages, open dialogs, etc. Dialog animation duration is not controlled by apps and the default transition duration for stack is already 300ms. I also left off the state/element transition since I can't think of any examples where we would use this currently outside the stylesheet. If it turns out we do want to use these other transition values I figure we can add them in a follow-up branch