### PR TITLE
Add StartupWMClass for demo

### DIFF
--- a/demo/io.elementary.granite.demo.desktop
+++ b/demo/io.elementary.granite.demo.desktop
@@ -5,3 +5,4 @@ Exec=granite-demo
 Icon=applications-interfacedesign
 Type=Application
 NoDisplay=true
+StartupWMClass=granite-demo


### PR DESCRIPTION
As discussed in https://github.com/elementary/gala/pull/939#issuecomment-716912596

Because the exec name does not match the desktop file, we need to give Gala a hint on how to match the window to the desktop file.

This will resolve the fact that the Granite Demo no longer has an icon in the window switcher, multitasking view, etc... with the latest Gala dailies.