### PR TITLE
MessageDialog: use messagedialog css name

### DIFF
--- a/lib/Widgets/MessageDialog.vala
+++ b/lib/Widgets/MessageDialog.vala
@@ -256,8 +256,7 @@ public class Granite.MessageDialog : Gtk.Dialog {
     }
 
     class construct {
-        // We don't use Gtk.STYLE_CLASS_MESSAGE_DIALOG here because it incorrectly contains a `-`
-        set_css_name ("messagedialog");
+        set_css_name (Gtk.STYLE_CLASS_MESSAGE_DIALOG);
     }
 
     construct {

--- a/lib/Widgets/MessageDialog.vala
+++ b/lib/Widgets/MessageDialog.vala
@@ -256,7 +256,8 @@ public class Granite.MessageDialog : Gtk.Dialog {
     }
 
     class construct {
-        set_css_name (Gtk.STYLE_CLASS_MESSAGE_DIALOG);
+        // We don't use Gtk.STYLE_CLASS_MESSAGE_DIALOG here because it incorrectly contains a `-`
+        set_css_name ("messagedialog");
     }
 
     construct {

--- a/lib/Widgets/MessageDialog.vala
+++ b/lib/Widgets/MessageDialog.vala
@@ -255,6 +255,10 @@ public class Granite.MessageDialog : Gtk.Dialog {
         );
     }
 
+    class construct {
+        set_css_name (Gtk.STYLE_CLASS_MESSAGE_DIALOG);
+    }
+
     construct {
         resizable = false;
         deletable = false;


### PR DESCRIPTION
Make sure we use the correct `messagedialog` css name instead of just `dialog`