### PR TITLE
Revert "Get prefers accent color from AccountsService"

### DIFF
--- a/data/granite.appdata.xml.in
+++ b/data/granite.appdata.xml.in
@@ -14,7 +14,6 @@
       <description>
         <p>Additions:</p>
         <ul>
-          <li>Settings.prefers_accent_color to get a user's accent color preference</li>
           <li>force_elementary_style to set the app's icons, cursors, and stylesheet to elementary defaults</li>
         </ul>
         <p>Other Changes:</p>

--- a/lib/Widgets/Settings.vala
+++ b/lib/Widgets/Settings.vala
@@ -2,7 +2,6 @@
 namespace Granite {
     [DBus (name = "io.elementary.pantheon.AccountsService")]
     private interface Pantheon.AccountsService : Object {
-        public abstract int prefers_accent_color { owned get; set; }
         public abstract int prefers_color_scheme { owned get; set; }
     }
 
@@ -15,56 +14,6 @@ namespace Granite {
      * Granite.Settings provides a way to share Pantheon desktop settings with applications.
      */
     public class Settings : Object {
-        /**
-         * Possible accent color preferences expressed by the user
-         */
-         public enum AccentColor {
-            /**
-             * The user has not expressed a accent color preference.
-             */
-            NO_PREFERENCE,
-            /**
-             * The user prefers red as accent color.
-             */
-            RED,
-            /**
-             * The user prefers orange as accent color.
-             */
-            ORANGE,
-            /**
-             * The user prefers yellow as accent color.
-             */
-            YELLOW,
-            /**
-             * The user prefers green as accent color.
-             */
-            GREEN,
-            /**
-             * The user prefers mint as accent color.
-             */
-            MINT,
-            /**
-             * The user prefers blue as accent color.
-             */
-            BLUE,
-            /**
-             * The user prefers purple as accent color.
-             */
-            PURPLE,
-            /**
-             * The user prefers pink as accent color.
-             */
-            PINK,
-            /**
-             * The user prefers brown as accent color.
-             */
-            BROWN,
-            /**
-             * The user prefers gray as accent color.
-             */
-            GRAY
-        }
-
         /**
          * Possible color scheme preferences expressed by the user
          */
@@ -83,23 +32,7 @@ namespace Granite {
             LIGHT
         }
 
-        private AccentColor? _prefers_accent_color = null;
         private ColorScheme? _prefers_color_scheme = null;
-
-        /**
-         * Accent color the user would prefer or if the user has expressed no preference.
-         */
-         public AccentColor prefers_accent_color {
-            get {
-                if (_prefers_accent_color == null) {
-                    setup_prefers_accent_color ();
-                }
-                return _prefers_accent_color;
-            }
-            private set {
-                _prefers_accent_color = value;
-            }
-        }
 
         /**
          * Whether the user would prefer if apps use a dark or light color scheme or if the user has expressed no preference.
@@ -150,28 +83,6 @@ namespace Granite {
                 );
 
                 _user_path = accounts_service.find_user_by_name (GLib.Environment.get_user_name ());
-            } catch (Error e) {
-                critical (e.message);
-            }
-        }
-
-        private void setup_prefers_accent_color () {
-            try {
-                pantheon_act = GLib.Bus.get_proxy_sync (
-                    GLib.BusType.SYSTEM,
-                    "org.freedesktop.Accounts",
-                    user_path,
-                    GLib.DBusProxyFlags.GET_INVALIDATED_PROPERTIES
-                );
-
-                prefers_accent_color = (AccentColor) pantheon_act.prefers_accent_color;
-
-                ((GLib.DBusProxy) pantheon_act).g_properties_changed.connect ((changed, invalid) => {
-                    var accent_color = changed.lookup_value ("PrefersAccentColor", new VariantType ("i"));
-                    if (accent_color != null) {
-                        prefers_accent_color = (AccentColor) accent_color.get_int32 ();
-                    }
-                });
             } catch (Error e) {
                 critical (e.message);
             }


### PR DESCRIPTION
Reverts elementary/granite#483

This seems only interesting to two very specific applications and isn't a good long-term solution for flatpak'd apps, as we don't really want them to be adding accountsservice to their sandbox.