### PR TITLE
Fix accel_to_string to not automatically add a '+' character unless needed

### DIFF
--- a/data/granite.appdata.xml.in
+++ b/data/granite.appdata.xml.in
@@ -18,6 +18,7 @@
         </ul>
         <p>Other Changes:</p>
         <ul>
+          <li>accel_to_string handles accel markup without modifiers or that are only modifiers</li>
           <li>Updated translations</li>
         </ul>
       </description>

--- a/demo/Views/UtilsView.vala
+++ b/demo/Views/UtilsView.vala
@@ -34,11 +34,11 @@ public class UtilsView : Gtk.Grid {
         tooltip_markup_label.halign = Gtk.Align.END;
 
         var tooltip_button_one = new Gtk.Button.from_icon_name ("mail-reply-all", Gtk.IconSize.LARGE_TOOLBAR);
-        tooltip_button_one.tooltip_markup = Granite.markup_accel_tooltip ({"<Ctrl><Shift>R"}, "Reply All");
+        tooltip_button_one.tooltip_markup = Granite.markup_accel_tooltip ({"<Ctrl><Shift>R", "R"}, "Reply All");
 
         var tooltip_button_two = new Gtk.Button.with_label ("Label Buttons");
         tooltip_button_two.tooltip_markup = Granite.markup_accel_tooltip (
-            {"<Super>R", "<Ctrl><Shift>Up", "<Ctrl>Return"}
+            {"<Super>R", "<Ctrl><Shift>Up", "<Ctrl>Return", "<Super>"}
         );
 
         var contrasting_foreground_color_label = new Gtk.Label ("Contrasting Foreground Color:");

--- a/lib/Widgets/Utils.vala
+++ b/lib/Widgets/Utils.vala
@@ -173,7 +173,11 @@ public static string accel_to_string (string? accel) {
             break;
     }
 
-    return string.joinv (" + ", arr);
+    if (accel_key != 0 && accel_mods != 0) {
+        return string.joinv (" + ", arr);
+    }
+
+    return arr[0];
 }
 
 /**


### PR DESCRIPTION
This fixes the accel_to_string function so that it does not always add " + " to any accel passed to it. This is created to address a comment on [this pull request](https://github.com/elementary/applications-menu/pull/480) and includes an update to the demo to include both an accel without any mod and an accel that is only a mod.