### PR TITLE
Make sure to work accel_to_string with multiple modifiers

### DIFF
--- a/lib/Widgets/Utils.vala
+++ b/lib/Widgets/Utils.vala
@@ -170,7 +170,7 @@ public static string accel_to_string (string? accel) {
             break;
         default:
             // If a specified accelarator contains only modifiers e.g. "<Control><Shift>",
-            // we get anything from accelerator_get_label method, so skip that case
+            // we don't get anything from accelerator_get_label method, so skip that case
             string accel_label = Gtk.accelerator_get_label (accel_key, 0);
             if (accel_label != "") {
                 arr += accel_label;

--- a/lib/Widgets/Utils.vala
+++ b/lib/Widgets/Utils.vala
@@ -169,11 +169,16 @@ public static string accel_to_string (string? accel) {
             arr += _("Right Shift");
             break;
         default:
-            arr += Gtk.accelerator_get_label (accel_key, 0);
+            // If a specified accelarator contains only modifiers e.g. "<Control><Shift>",
+            // we get anything from accelerator_get_label method, so skip that case
+            string accel_label = Gtk.accelerator_get_label (accel_key, 0);
+            if (accel_label != "") {
+                arr += accel_label;
+            }
             break;
     }
 
-    if (accel_key != 0 && accel_mods != 0) {
+    if (accel_mods != 0) {
         return string.joinv (" + ", arr);
     }
 


### PR DESCRIPTION
## Before
If you pass `accel_to_string` to a accel that only contains modifiers e.g. "\<Shift\>\<Control\>" or "\<Shift\>\<Alt\>", it only return either of them, as seen in Shortcut Overlay:

![Screenshot from 2021-07-18 23-36-09](https://user-images.githubusercontent.com/26003928/126071537-a002064a-c40b-4afa-a8df-c3ccdec26f31.png)

## After
![Screenshot from 2021-07-18 23-33-31](https://user-images.githubusercontent.com/26003928/126071491-7c30d6df-7917-4d96-b7b4-830452ea2138.png)
