### PR TITLE
appdata: Fix a typo

### DIFF
--- a/data/granite.appdata.xml.in
+++ b/data/granite.appdata.xml.in
@@ -51,7 +51,7 @@
         <p>Other Changes:</p>
         <ul>
           <li>Toasts now reset their timeout when sending a new notification and the timeout is stopped while hovering</li>
-          <li>Backlash, Right Control, and Left Control are now handled by accel_to_string</li>
+          <li>Backslash, Right Control, and Left Control are now handled by accel_to_string</li>
           <li>Make tab tooltips of DynamicNotebook settable</li>
           <li>Timepicker corrrectly fires time_changed when AM and PM buttons are selected</li>
           <li>Granite.MessageDialog now uses the messagedialog CSS name</li>


### PR DESCRIPTION
From [the comment](https://l10n.elementary.io/translate/desktop/granite-extra/en/?checksum=9a5cffb934bf6f0e#comments) by supaeasy in weblate.
