### PR TITLE
Add instruction for accessing AccountsService from Flatpak

### DIFF
--- a/lib/Widgets/Settings.vala
+++ b/lib/Widgets/Settings.vala
@@ -36,6 +36,9 @@ namespace Granite {
 
         /**
          * Whether the user would prefer if apps use a dark or light color scheme or if the user has expressed no preference.
+         *
+         * To access this from a Flatpak application, add an entry with the value `'--system-talk-name=org.freedesktop.Accounts'`
+         * in the `finish-args` array of your Flatpak manifest.
          */
         public ColorScheme prefers_color_scheme {
             get {


### PR DESCRIPTION
Closes #512.

I skipped the bullet hyphen because it wouldn't make sense for JSON manifests.

I am not sure if backticks are the right way to mark up code in Valadoc. Let me know if it is incorrect.