### PR TITLE
l10n: Correctly setup the locales

### DIFF
--- a/lib/Config.vala.in
+++ b/lib/Config.vala.in
@@ -19,4 +19,5 @@
 
 namespace Granite {
     private const string GETTEXT_PACKAGE = "@GETTEXT_PACKAGE@";
+    private const string LOCALEDIR = "@LOCALEDIR@";
 }

--- a/lib/Widgets/AccelLabel.vala
+++ b/lib/Widgets/AccelLabel.vala
@@ -76,6 +76,11 @@ public class Granite.AccelLabel : Gtk.Grid {
     }
 
     construct {
+        GLib.Intl.setlocale (LocaleCategory.ALL, "");
+        GLib.Intl.textdomain (Granite.GETTEXT_PACKAGE);
+        GLib.Intl.bindtextdomain (Granite.GETTEXT_PACKAGE, Granite.LOCALEDIR);
+        GLib.Intl.bind_textdomain_codeset (Granite.GETTEXT_PACKAGE, "UTF-8");
+
         var label = new Gtk.Label (label);
         label.hexpand = true;
         label.margin_end = 6;

--- a/lib/Widgets/DynamicNotebook.vala
+++ b/lib/Widgets/DynamicNotebook.vala
@@ -271,6 +271,11 @@ namespace Granite.Widgets {
         }
 
         construct {
+            GLib.Intl.setlocale (LocaleCategory.ALL, "");
+            GLib.Intl.textdomain (Granite.GETTEXT_PACKAGE);
+            GLib.Intl.bindtextdomain (Granite.GETTEXT_PACKAGE, Granite.LOCALEDIR);
+            GLib.Intl.bind_textdomain_codeset (Granite.GETTEXT_PACKAGE, "UTF-8");
+
             _label = new Gtk.Label (null);
             _label.hexpand = true;
             _label.tooltip_text = label;
@@ -825,6 +830,11 @@ namespace Granite.Widgets {
         }
 
         construct {
+            GLib.Intl.setlocale (LocaleCategory.ALL, "");
+            GLib.Intl.textdomain (Granite.GETTEXT_PACKAGE);
+            GLib.Intl.bindtextdomain (Granite.GETTEXT_PACKAGE, Granite.LOCALEDIR);
+            GLib.Intl.bind_textdomain_codeset (Granite.GETTEXT_PACKAGE, "UTF-8");
+
             notebook = new Gtk.Notebook ();
             notebook.can_focus = false;
             visible_window = true; // needed for leave_notify event

--- a/lib/Widgets/MessageDialog.vala
+++ b/lib/Widgets/MessageDialog.vala
@@ -132,6 +132,11 @@ public class Granite.MessageDialog : Granite.Dialog {
      */
     public Gtk.ButtonsType buttons {
         construct {
+            GLib.Intl.setlocale (LocaleCategory.ALL, "");
+            GLib.Intl.textdomain (Granite.GETTEXT_PACKAGE);
+            GLib.Intl.bindtextdomain (Granite.GETTEXT_PACKAGE, Granite.LOCALEDIR);
+            GLib.Intl.bind_textdomain_codeset (Granite.GETTEXT_PACKAGE, "UTF-8");
+
             switch (value) {
                 case Gtk.ButtonsType.NONE:
                     break;

--- a/lib/Widgets/StorageBar.vala
+++ b/lib/Widgets/StorageBar.vala
@@ -159,6 +159,11 @@ public class Granite.Widgets.StorageBar : Gtk.Box {
     }
 
     construct {
+        GLib.Intl.setlocale (LocaleCategory.ALL, "");
+        GLib.Intl.textdomain (Granite.GETTEXT_PACKAGE);
+        GLib.Intl.bindtextdomain (Granite.GETTEXT_PACKAGE, Granite.LOCALEDIR);
+        GLib.Intl.bind_textdomain_codeset (Granite.GETTEXT_PACKAGE, "UTF-8");
+
         orientation = Gtk.Orientation.VERTICAL;
         description_label = new Gtk.Label (null);
         description_label.hexpand = true;

--- a/lib/Widgets/TimePicker.vala
+++ b/lib/Widgets/TimePicker.vala
@@ -87,6 +87,11 @@ namespace Granite.Widgets {
         }
 
         construct {
+            GLib.Intl.setlocale (LocaleCategory.ALL, "");
+            GLib.Intl.textdomain (Granite.GETTEXT_PACKAGE);
+            GLib.Intl.bindtextdomain (Granite.GETTEXT_PACKAGE, Granite.LOCALEDIR);
+            GLib.Intl.bind_textdomain_codeset (Granite.GETTEXT_PACKAGE, "UTF-8");
+
             if (format_12 == null) {
                 format_12 = Granite.DateTime.get_default_time_format (true);
             }

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -66,6 +66,7 @@ include_dir = join_paths(
 
 config_data = configuration_data()
 config_data.set('GETTEXT_PACKAGE', meson.project_name())
+config_data.set('LOCALEDIR', join_paths(get_option('prefix'), get_option('localedir')))
 config_vala = configure_file(
     input: 'Config.vala.in',
     output: '@BASENAME@',


### PR DESCRIPTION
Provides the directory where the locales are actually installed.

We are [packaging this](https://github.com/NixOS/nixpkgs/pull/130380#issuecomment-895720580) in NixOS, and due to NixOS 's special `localedir`, we cannot apply the translations without this patch.
