### PR TITLE
Disable SettingsPage horizontal scrolling

### DIFF
--- a/lib/Widgets/AbstractSettingsPage.vala
+++ b/lib/Widgets/AbstractSettingsPage.vala
@@ -65,4 +65,8 @@ public abstract class Granite.SettingsPage : Gtk.ScrolledWindow {
             _title = value;
         }
     }
+
+    construct {
+        hscrollbar_policy = Gtk.PolicyType.NEVER;
+    }
 }


### PR DESCRIPTION
Per a discussion in Slack.

Currently, the main container of a SettingsPage can scroll horizontally. This can lead it to truncate its contents, which looks strange. For example, in the privacy settings page:
![Bildschirmfoto von 2021-09-03 15 03 54](https://user-images.githubusercontent.com/29022469/132065154-102a8f61-19d9-4b93-8bde-cfa1d5115363.png)

This PR disables horizontal scrolling so that the window is restricted to the horizontal size of the settings page children.

From previous experiments in the Gtk debugger, it seems like this should work. I'm not sure how to test it without overwriting my system Granite install (not sure the consequences of that one), since some container higher up in the granite-demo window appears to allow its children to be horizontally truncated. (I tested it on other settings pages, which were all truncated the same way, so I don't think the behavior I'm seeing in the demo is a result of SettingsPage.) So let me know if it doesn't work for you.