### PR TITLE
Expose clock format as granite setting

### DIFF
--- a/demo/Views/DateTimePickerView.vala
+++ b/demo/Views/DateTimePickerView.vala
@@ -32,12 +32,16 @@ public class DateTimePickerView : Gtk.Grid {
         current_time_label.halign = Gtk.Align.END;
 
         var now = new DateTime.now_local ();
-        var settings = new Settings ("org.gnome.desktop.interface");
-        var time_format = Granite.DateTime.get_default_time_format (settings.get_enum ("clock-format") == 1, false);
+        var settings = Granite.Settings.get_default ();
+        var time_format = Granite.DateTime.get_default_time_format (settings.clock_format == Granite.Settings.ClockFormat.12H, false);
 
-        var current_time = new Gtk.Label (now.format (time_format));
+        var current_time = new Gtk.Label (Granite.DateTime.format_time(now, false));
         current_time.tooltip_text = time_format;
         current_time.xalign = 0;
+
+        settings.notify["clock-format"].connect(() => {
+           current_time.label = Granite.DateTime.format_time(now, false);
+        });
 
         var current_date_label = new Gtk.Label ("Localized date:");
         current_date_label.halign = Gtk.Align.END;

--- a/lib/DateTime.vala
+++ b/lib/DateTime.vala
@@ -9,11 +9,6 @@
  */
 namespace Granite.DateTime {
 
-    [DBus (name = "org.freedesktop.portal.Settings")]
-    private interface FDO.Portal.Settings : Object {
-        public abstract Variant read (string @namespace, string key);
-    }
-
     /**
      * Gets a default translated time format.
      * The function constructs a new string interpreting the //is_12h// and //with_second// parameters
@@ -102,17 +97,8 @@ namespace Granite.DateTime {
      * @return true if the clock format is 12h based, false otherwise.
      */
     private static bool is_clock_format_12h () {
-        FDO.Portal.Settings settings_bus = GLib.Bus.get_proxy_sync (
-                    GLib.BusType.SESSION,
-                   "org.freedesktop.portal.Desktop",
-                   "/org/freedesktop/portal/desktop"
-                );
-        
-        var clock_format_variant = settings_bus.read ("org.gnome.desktop.interface", "clock-format").get_variant ();
-        var format = clock_format_variant.get_string ();
-
-        
-        return (format.contains ("12h"));
+        var settings = Granite.Settings.get_default ();
+        return settings.clock_format == Granite.Settings.ClockFormat.12H;
     }
 
     /**

--- a/lib/DateTime.vala
+++ b/lib/DateTime.vala
@@ -14,13 +14,13 @@ namespace Granite.DateTime {
      * The function constructs a new string interpreting the //is_12h// and //with_second// parameters
      * so that it can be used with formatting functions like {@link GLib.DateTime.format}.
      *
-     * The returned string is formatted and translated. This function is mostly used to display
+     * The returned format string is formatted and translated. This function is mostly used to display
      * the time in various user interfaces like the time displayed in the top panel.
      *
      * @param is_12h if the returned string should be formatted in 12h format
      * @param with_second if the returned string should include seconds
      *
-     * @return the formatted and located time string.
+     * @return the formatted and located time format string.
      */
     public static string get_default_time_format (bool is_12h = false, bool with_second = false) {
         if (is_12h == true) {
@@ -40,6 +40,22 @@ namespace Granite.DateTime {
                 return _("%H:%M");
             }
         }
+    }
+    
+    /**
+     * Formats a {@link GLib.DateTime} using defaults from desktop settings
+     *
+     * The returned string is formatted and translated. This function is mostly used to display
+     * the time in various user interfaces like the time displayed in the top panel.
+     *
+     * @param date_time a {@link GLib.DateTime} to format using the desktop settings
+     * @param with_second if the returned string should include seconds
+     * @return the formatted and located time string.
+     */
+    public static string format_time (GLib.DateTime date_time, bool with_second = false) {
+        var is_12h = is_clock_format_12h ();
+        var time_format = get_default_time_format (is_12h, with_second);
+        return date_time.format (time_format);
     }
 
     /**

--- a/lib/DateTime.vala
+++ b/lib/DateTime.vala
@@ -8,6 +8,12 @@
  * getting the default translated format for either date and time.
  */
 namespace Granite.DateTime {
+
+    [DBus (name = "org.freedesktop.portal.Settings")]
+    private interface FDO.Portal.Settings : Object {
+        public abstract Variant read (string @namespace, string key);
+    }
+
     /**
      * Gets a default translated time format.
      * The function constructs a new string interpreting the //is_12h// and //with_second// parameters
@@ -96,8 +102,16 @@ namespace Granite.DateTime {
      * @return true if the clock format is 12h based, false otherwise.
      */
     private static bool is_clock_format_12h () {
-        var h24_settings = new GLib.Settings ("org.gnome.desktop.interface");
-        var format = h24_settings.get_string ("clock-format");
+        FDO.Portal.Settings settings_bus = GLib.Bus.get_proxy_sync (
+                    GLib.BusType.SESSION,
+                   "org.freedesktop.portal.Desktop",
+                   "/org/freedesktop/portal/desktop"
+                );
+        
+        var clock_format_variant = settings_bus.read ("org.gnome.desktop.interface", "clock-format").get_variant ();
+        var format = clock_format_variant.get_string ();
+
+        
         return (format.contains ("12h"));
     }
 

--- a/lib/Widgets/TimePicker.vala
+++ b/lib/Widgets/TimePicker.vala
@@ -185,6 +185,13 @@ namespace Granite.Widgets {
             activate.connect (is_unfocused);
 
             update_text ();
+            
+            var granite_settings = Granite.Settings.get_default ();
+            
+            granite_settings.notify["clock-format"].connect (() => {
+                update_text ();
+                set_popover_clock_format ();
+            });
         }
 
         private void update_time (bool is_hour) {
@@ -222,6 +229,14 @@ namespace Granite.Widgets {
         private void on_icon_press (Gtk.EntryIconPosition position, Gdk.Event event) {
             // If the mode is changed from 12h to 24h or visa versa, the entry updates on icon press
             update_text ();
+
+            set_popover_clock_format ();
+
+            popover.pointing_to = get_icon_area (Gtk.EntryIconPosition.SECONDARY);
+            popover.show_all ();
+        }
+        
+        private void set_popover_clock_format () {
             changing_time = true;
 
             if (Granite.DateTime.is_clock_format_12h () && time.get_hour () > 12) {
@@ -245,18 +260,16 @@ namespace Granite.Widgets {
                 // Make sure that bounds are set correctly
                 hours_spinbutton.set_range (1, 12);
             } else {
+            
+                hours_spinbutton.set_range (0, 23);
+            
                 am_pm_modebutton.no_show_all = true;
                 am_pm_modebutton.hide ();
                 hours_spinbutton.set_value (time.get_hour ());
-
-                hours_spinbutton.set_range (0, 23);
             }
 
             minutes_spinbutton.set_value (time.get_minute ());
             changing_time = false;
-
-            popover.pointing_to = get_icon_area (Gtk.EntryIconPosition.SECONDARY);
-            popover.show_all ();
         }
 
         [Version (deprecated = true, deprecated_since = "5.2.0")]


### PR DESCRIPTION
This builds on #527 , but also solves some needs in #525 

This:

- exposes the clock format as setting in Granite.Settings, including listening from updates, using the portal. This also allows applications to notify on the update even inside a flatpak'ed application
- updates internal APIs and widgets to use the new setting, including listening on updates. This magically makes applications work inside flatpak as well as makes them more dynamic (i.e., when the system setting is changed, reflect that change instantly)
- adds a new API to format a GLib.DateTime directly using the existing APIs and the system settings so that applications don't have to duplicate the format logic everywhere.
