### PR TITLE
Support the settings portal where is possible

### DIFF
--- a/lib/DateTime.vala
+++ b/lib/DateTime.vala
@@ -96,8 +96,20 @@ namespace Granite.DateTime {
      * @return true if the clock format is 12h based, false otherwise.
      */
     private static bool is_clock_format_12h () {
-        var h24_settings = new GLib.Settings ("org.gnome.desktop.interface");
-        var format = h24_settings.get_string ("clock-format");
+        string format = null;
+        try {
+            var portal = Portal.Settings.get ();
+            var variant = portal.read ("org.gnome.desktop.interface", "clock-format").get_variant ();
+            format = variant.get_string ();
+        } catch (Error e) {
+            debug ("cannot use portal, using GSettings: %s", e.message);
+        }
+
+        if (format == null) {
+            var h24_settings = new GLib.Settings ("org.gnome.desktop.interface");
+            format = h24_settings.get_string ("clock-format");
+        }
+
         return (format.contains ("12h"));
     }
 

--- a/lib/Services/Portal.vala
+++ b/lib/Services/Portal.vala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2021 elementary, Inc. (https://elementary.io)
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+namespace Granite.Portal {
+    private const string DBUS_DESKTOP_PATH = "/org/freedesktop/portal/desktop";
+    private const string DBUS_DESKTOP_NAME = "org.freedesktop.portal.Desktop";
+
+    [DBus (name = "org.freedesktop.portal.Settings")]
+    interface Settings : Object {
+        public static Settings @get () throws Error {
+            return Bus.get_proxy_sync (
+                BusType.SESSION,
+                DBUS_DESKTOP_NAME,
+                DBUS_DESKTOP_PATH,
+                DBusProxyFlags.NONE
+            );
+        }
+
+        public abstract HashTable<string, HashTable<string, Variant>> read_all (string[] namespaces) throws DBusError, IOError;
+        public abstract Variant read (string namespace, string key) throws DBusError, IOError;
+
+        public signal void setting_changed (string namespace, string key, Variant value);
+    }
+}

--- a/lib/Services/System.vala
+++ b/lib/Services/System.vala
@@ -170,6 +170,7 @@ namespace Granite.Services {
 
         private static GLib.SettingsSchema? privacy_settings_schema = null;
         private static GLib.Settings? privacy_settings = null;
+        private static Portal.Settings? portal = null;
 
         /**
          * Returns whether history is enabled within the Security and Privacy system settings or not. A value of true
@@ -178,6 +179,19 @@ namespace Granite.Services {
          * Checks the "remember_recent_files" key in "org.gnome.desktop.privacy", returning true if the schema does not exist.
          */
         public static bool history_is_enabled () {
+            try {
+                if (portal == null) {
+                    portal = Portal.Settings.get ();
+                }
+
+                var schemes = portal.read_all ({ "org.gnome.desktop.privacy" });
+                if (schemes.length > 0 && "remember-recent-files" in schemes["org.gnome.desktop.privacy"]) {
+                    return schemes["org.gnome.desktop.privacy"]["remember-recent-files"].get_boolean ();
+                }
+            } catch (Error e) {
+                debug ("cannot use portal, using GSettings: %s", e.message);
+            }
+
             if (privacy_settings_schema == null) {
                 privacy_settings_schema = SettingsSchemaSource.get_default ().lookup ("org.gnome.desktop.privacy", true);
             }

--- a/lib/Widgets/Settings.vala
+++ b/lib/Widgets/Settings.vala
@@ -78,6 +78,7 @@ namespace Granite {
 
         private FDO.Accounts? accounts_service = null;
         private Pantheon.AccountsService? pantheon_act = null;
+        private Portal.Settings? portal = null;
 
         private Settings () {}
 
@@ -96,6 +97,24 @@ namespace Granite {
         }
 
         private void setup_prefers_color_scheme () {
+            try {
+                portal = Portal.Settings.get ();
+
+                prefers_color_scheme = (ColorScheme) portal.read (
+                    "org.freedesktop.appearance",
+                    "color-scheme"
+                ).get_variant ().get_uint32 ();
+
+                portal.setting_changed.connect ((scheme, key, value) => {
+                    if (scheme == "org.freedesktop.appearance" && key == "color-scheme") {
+                        prefers_color_scheme = (ColorScheme) value.get_uint32 ();
+                    }
+                });
+                return;
+            } catch (Error e) {
+                debug ("cannot use the portal, using the AccountsService: %s", e.message);
+            }
+
             try {
                 pantheon_act = GLib.Bus.get_proxy_sync (
                     GLib.BusType.SYSTEM,

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -14,6 +14,7 @@ libgranite_sources = files(
     'Services/IconFactory.vala',
     'Services/Logger.vala',
     'Services/Paths.vala',
+    'Services/Portal.vala',
     'Services/Settings.vala',
     'Services/SimpleCommand.vala',
     'Services/System.vala',


### PR DESCRIPTION
blocked by elementary/settings-daemon#38

This make the functions that read some setting provided by the portal to try it first, allowing we get the right values when sandboxed.