### PR TITLE
AppData: Explicit namespace of the removed Settings

### DIFF
--- a/data/granite.appdata.xml.in
+++ b/data/granite.appdata.xml.in
@@ -25,7 +25,7 @@
           <li>ModeButton: Use Gtk.ToggleButton with the "group" property and "linked" style class instead</li>
           <li>Paths: use GLib.Environment instead</li>
           <li>Seekbar</li>
-          <li>Settings: use GLib.Settings instead</li>
+          <li>Services.Settings: use GLib.Settings instead</li>
           <li>SimpleCommand: use GLib.AppInfo.create_from_commandline instead</li>
           <li>SourceList: use Gtk.ListBox with the "sidebar" style class instead</li>
           <li>StorageBar</li>


### PR DESCRIPTION
We had two classes named "Settings": `Granite.Service.Settings` which have just removed and `Granite.Settings` for color preferences. This is really a tiny thing but we may want to explicit that the removed Settings class here is the one in the Service namespace and not the latter one.
