### PR TITLE
debian: Rename package in changelog

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-granite (7.0.0) bionic; urgency=medium
+granite7 (7.0.0) bionic; urgency=medium
 
   * Release 7.0.0 (#599)
   * MessageDialog: set window title to primary text


### PR DESCRIPTION
The release action just bumps the previous package name, but we renamed for this release.