### PR TITLE
Make Toast Wrap

### DIFF
--- a/demo/Views/ToastView.vala
+++ b/demo/Views/ToastView.vala
@@ -26,6 +26,7 @@ public class ToastView : Gtk.Box {
 
         overlay.add_overlay (box);
         overlay.add_overlay (toast);
+        overlay.set_measure_overlay (toast, true);
 
         button.clicked.connect (() => {
             toast.send_notification ();

--- a/lib/Widgets/Toast.vala
+++ b/lib/Widgets/Toast.vala
@@ -71,7 +71,9 @@ public class Granite.Toast : Gtk.Widget {
             visible = false
         };
 
-        var close_button = new Gtk.Button.from_icon_name ("window-close-symbolic");
+        var close_button = new Gtk.Button.from_icon_name ("window-close-symbolic") {
+            valign = Gtk.Align.CENTER
+        };
         close_button.add_css_class (Granite.STYLE_CLASS_CIRCULAR);
 
         notification_label = new Gtk.Label (title) {

--- a/lib/Widgets/Toast.vala
+++ b/lib/Widgets/Toast.vala
@@ -78,7 +78,8 @@ public class Granite.Toast : Gtk.Widget {
 
         notification_label = new Gtk.Label (title) {
             wrap = true,
-            wrap_mode = Pango.WrapMode.WORD
+            wrap_mode = Pango.WrapMode.WORD,
+            natural_wrap_mode = Gtk.NaturalWrapMode.NONE
         };
 
         var box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);

--- a/lib/Widgets/Toast.vala
+++ b/lib/Widgets/Toast.vala
@@ -74,7 +74,10 @@ public class Granite.Toast : Gtk.Widget {
         var close_button = new Gtk.Button.from_icon_name ("window-close-symbolic");
         close_button.add_css_class (Granite.STYLE_CLASS_CIRCULAR);
 
-        notification_label = new Gtk.Label (title);
+        notification_label = new Gtk.Label (title) {
+            wrap = true,
+            wrap_mode = Pango.WrapMode.WORD
+        };
 
         var box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
         box.add_css_class (Granite.STYLE_CLASS_OSD);


### PR DESCRIPTION
When the 'Grantie.Toast' title gets too long, for example when used to toast long filenames, the 'Granite.Toast' continues to expand horizontally regardless of the parent window. This aims to fix it.

**Before** 
![Screenshot from 2022-05-26 08 28 44](https://user-images.githubusercontent.com/73321827/170391756-9e4de555-a4fd-4257-a68e-e7c5847c8bc5.png)

**After**
![Screenshot from 2022-05-26 08 42 24](https://user-images.githubusercontent.com/73321827/170392080-f22f25be-9179-43d7-bfe1-f30a828bfdc2.png)
