### PR TITLE
Added missing style constants (sidebar + background)

### DIFF
--- a/data/granite.appdata.xml.in
+++ b/data/granite.appdata.xml.in
@@ -20,6 +20,7 @@
         <p>Improvements:</p>
         <ul>
           <li>MessageDialog: fix a bug that caused large heights to be preserved</li>
+          <li>Constants: Added STYLE_CLASS_SIDEBAR and STYLE_CLASS_BACKGROUND constants</li>
           <li>Updated translations</li>
         </ul>
       </description>

--- a/lib/Constants.vala
+++ b/lib/Constants.vala
@@ -8,11 +8,14 @@ namespace Granite {
      * Style class to give accent color to a {@link Gtk.Label} or symbolic icon
      */
     public const string STYLE_CLASS_ACCENT = "accent";
-
     /**
      * Style class for shaping a {@link Gtk.Button}
      */
     public const string STYLE_CLASS_BACK_BUTTON = "back-button";
+    /**
+     * Style class to match the window background
+     */
+    public const string STYLE_CLASS_BACKGROUND = "background";
     /**
      * Style class for numbered badges
      */
@@ -83,6 +86,10 @@ namespace Granite {
      * Style class for rounded corners, i.e. on a {@link Gtk.Window} or {@link Granite.STYLE_CLASS_CARD}
      */
     public const string STYLE_CLASS_ROUNDED = "rounded";
+    /**
+     * Style class defining a sidebar, such as the left side in a file chooser
+     */
+    public const string STYLE_CLASS_SIDEBAR = "sidebar";
     /**
      * Style class for a {@link Gtk.Label} to emulate Pango's "<small>" and "size='smaller'"
      */


### PR DESCRIPTION
Adds the missing style classes discussed in https://github.com/elementary/granite/issues/617 as constants