### PR TITLE
Constants: add large-icons

### DIFF
--- a/lib/Constants.vala
+++ b/lib/Constants.vala
@@ -75,7 +75,8 @@ namespace Granite {
      */
     public const string STYLE_CLASS_KEYCAP = "keycap";
     /**
-     * Style class for a {@link Gtk.Image} used to set a context-aware large icon size
+     * Style class for a {@link Gtk.Image} used to set a context-aware large icon size. By default this is 32px,
+     * but in certain contexts it could be larger or smaller depending on the default assumed icon size.
      */
     public const string STYLE_CLASS_LARGE_ICONS = "large-icons";
     /**

--- a/lib/Constants.vala
+++ b/lib/Constants.vala
@@ -75,6 +75,10 @@ namespace Granite {
      */
     public const string STYLE_CLASS_KEYCAP = "keycap";
     /**
+     * Style class for a {@link Gtk.Image} used to set a context-aware large icon size
+     */
+    public const string STYLE_CLASS_LARGE_ICONS = "large-icons";
+    /**
      * Style class for a {@link Gtk.Switch} used to change between two modes rather than active and inactive states
      */
     public const string STYLE_CLASS_MODE_SWITCH = "mode-switch";


### PR DESCRIPTION
This style class is used by Gtk.Image, so we support it too. See also https://github.com/elementary/stylesheet/pull/1222