### PR TITLE
SimpleSettingsPage: layout text smarter at small widths

### DIFF
--- a/lib/Widgets/AbstractSimpleSettingsPage.vala
+++ b/lib/Widgets/AbstractSimpleSettingsPage.vala
@@ -66,8 +66,9 @@ public abstract class Granite.SimpleSettingsPage : Granite.SettingsPage {
         };
 
         var title_label = new Gtk.Label (title) {
-            ellipsize = Pango.EllipsizeMode.END,
+            hexpand = true,
             selectable = true,
+            wrap = true,
             xalign = 0
         };
         title_label.add_css_class (Granite.STYLE_CLASS_H2_LABEL);
@@ -85,16 +86,14 @@ public abstract class Granite.SimpleSettingsPage : Granite.SettingsPage {
             };
 
             header_area.attach (header_icon, 0, 0, 1, 2);
-            header_area.attach (description_label, 1, 1);
+            header_area.attach (description_label, 1, 1, 2);
         } else {
             header_area.attach (header_icon, 0, 0);
         }
 
         if (activatable) {
             status_switch = new Gtk.Switch () {
-                hexpand = true,
-                halign = Gtk.Align.END,
-                valign = Gtk.Align.CENTER
+                valign = Gtk.Align.START
             };
             header_area.attach (status_switch, 2, 0);
         }


### PR DESCRIPTION
* Wrap titles instead of ellipsize
* Valign switches so they always sit in the top right corner, even with wrapped titles
* Let description text go under the switch

## BEFORE

![Screenshot from 2022-09-07 07 39 42](https://user-images.githubusercontent.com/7277719/188907610-38019d9d-3400-45ee-8631-1a3d1b3edf70.png)

## AFTER

![Screenshot from 2022-09-07 07 33 54](https://user-images.githubusercontent.com/7277719/188907615-5459f1a7-62b8-4047-8626-e22e84c41d5a.png)

![Screenshot from 2022-09-07 07 40 34](https://user-images.githubusercontent.com/7277719/188907605-90d0a3c7-2757-4ad4-99e4-9986d3dcccc2.png)