### PR TITLE
HeaderLabel: add optional body text

### DIFF
--- a/demo/Views/CSSView.vala
+++ b/demo/Views/CSSView.vala
@@ -29,10 +29,9 @@ public class CSSView : Gtk.Box {
         };
         header4.get_style_context ().add_class (Granite.STYLE_CLASS_H4_LABEL);
 
-        var card_header = new Granite.HeaderLabel (
-            "Cards and Headers",
-            "\"card\" with \"rounded\" and \"checkerboard\" style classes"
-        );
+        var card_header = new Granite.HeaderLabel ("Cards and Headers") {
+            secondary_text = "\"card\" with \"rounded\" and \"checkerboard\" style classes"
+        };
 
         var card = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
         card.add_css_class (Granite.STYLE_CLASS_CARD);
@@ -43,10 +42,9 @@ public class CSSView : Gtk.Box {
         card.append (header3);
         card.append (header4);
 
-        var richlist_label = new Granite.HeaderLabel (
-            "Lists",
-            "\"rich-list\" and \"frame\" style classes"
-        );
+        var richlist_label = new Granite.HeaderLabel ("Lists") {
+            secondary_text = "\"rich-list\" and \"frame\" style classes"
+        };
 
         var rich_listbox = new Gtk.ListBox () {
             show_separators = true
@@ -79,10 +77,9 @@ public class CSSView : Gtk.Box {
         };
         back_button.get_style_context ().add_class (Granite.STYLE_CLASS_BACK_BUTTON);
 
-        var scales_header = new Granite.HeaderLabel (
-            "Scales",
-            "\"warmth\" and \"temperature\" style classes"
-        );
+        var scales_header = new Granite.HeaderLabel ("Scales") {
+            secondary_text = "\"warmth\" and \"temperature\" style classes"
+        };
 
         var warmth_scale = new Gtk.Scale.with_range (Gtk.Orientation.HORIZONTAL, 3500, 6000, 10) {
             draw_value = false,

--- a/demo/Views/CSSView.vala
+++ b/demo/Views/CSSView.vala
@@ -29,9 +29,10 @@ public class CSSView : Gtk.Box {
         };
         header4.get_style_context ().add_class (Granite.STYLE_CLASS_H4_LABEL);
 
-        var card_label = new Gtk.Label ("\"card\" with \"rounded\" and \"checkerboard\" style classes:") {
-            halign = Gtk.Align.END
-        };
+        var card_header = new Granite.HeaderLabel (
+            "Cards and Headers",
+            "\"card\" with \"rounded\" and \"checkerboard\" style classes"
+        );
 
         var card = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
         card.add_css_class (Granite.STYLE_CLASS_CARD);
@@ -42,9 +43,10 @@ public class CSSView : Gtk.Box {
         card.append (header3);
         card.append (header4);
 
-        var richlist_label = new Gtk.Label ("\"rich-list\" and \"frame\" style class:") {
-            halign = Gtk.Align.END
-        };
+        var richlist_label = new Granite.HeaderLabel (
+            "Lists",
+            "\"rich-list\" and \"frame\" style classes"
+        );
 
         var rich_listbox = new Gtk.ListBox () {
             show_separators = true
@@ -55,9 +57,7 @@ public class CSSView : Gtk.Box {
         rich_listbox.append (new Gtk.Label ("Row 2"));
         rich_listbox.append (new Gtk.Label ("Row 3"));
 
-        var terminal_label = new Gtk.Label ("\"terminal\" style class:") {
-            halign = Gtk.Align.END
-        };
+        var terminal_label = new Granite.HeaderLabel ("\"terminal\" style class");
 
         var terminal = new Gtk.Label ("[ 73%] Linking C executable granite-demo\n[100%] Built target granite-demo") {
             selectable = true,
@@ -72,18 +72,17 @@ public class CSSView : Gtk.Box {
         };
         terminal_scroll.add_css_class (Granite.STYLE_CLASS_TERMINAL);
 
-        var back_button_label = new Gtk.Label ("\"back-button\" style class:") {
-            halign = Gtk.Align.END
-        };
+        var back_button_label = new Granite.HeaderLabel ("\"back-button\" style class") ;
 
         var back_button = new Gtk.Button.with_label ("Back Button") {
             halign = Gtk.Align.START
         };
         back_button.get_style_context ().add_class (Granite.STYLE_CLASS_BACK_BUTTON);
 
-        var warmth_label = new Gtk.Label ("\"warmth\" style class:") {
-            halign = Gtk.Align.END
-        };
+        var scales_header = new Granite.HeaderLabel (
+            "Scales",
+            "\"warmth\" and \"temperature\" style classes"
+        );
 
         var warmth_scale = new Gtk.Scale.with_range (Gtk.Orientation.HORIZONTAL, 3500, 6000, 10) {
             draw_value = false,
@@ -94,10 +93,6 @@ public class CSSView : Gtk.Box {
         warmth_scale.set_value (6000);
         warmth_scale.get_style_context ().add_class (Granite.STYLE_CLASS_WARMTH);
 
-        var temperature_label = new Gtk.Label ("\"temperature\" style class:") {
-            halign = Gtk.Align.END
-        };
-
         var temperature_scale = new Gtk.Scale.with_range (Gtk.Orientation.HORIZONTAL, -16.0f, 16.0f, 1.0) {
             draw_value = false,
             has_origin = false,
@@ -106,15 +101,11 @@ public class CSSView : Gtk.Box {
         temperature_scale.set_value (0);
         temperature_scale.get_style_context ().add_class (Granite.STYLE_CLASS_TEMPERATURE);
 
-        var primary_color_label = new Gtk.Label ("Set HeaderBar color:") {
-            halign = Gtk.Align.END
-        };
+        var primary_color_label = new Granite.HeaderLabel ("Set HeaderBar color");
 
         var primary_color_button = new Gtk.ColorButton.with_rgba ({ 222, 222, 222, 255 });
 
-        var accent_color_label = new Gtk.Label ("Accent colored labels and icons:") {
-            halign = Gtk.Align.END
-        };
+        var accent_color_label = new Granite.HeaderLabel ("Accent colored labels and icons");
 
         var accent_color_icon = new Gtk.Image.from_icon_name ("emoji-body-symbolic");
         accent_color_icon.get_style_context ().add_class (Granite.STYLE_CLASS_ACCENT);
@@ -126,9 +117,7 @@ public class CSSView : Gtk.Box {
         accent_color_grid.append (accent_color_icon);
         accent_color_grid.append (accent_color_string);
 
-        var grid = new Gtk.Grid () {
-            column_spacing = 12,
-            row_spacing = 24,
+        var box = new Gtk.Box (Gtk.Orientation.VERTICAL, 12) {
             halign = Gtk.Align.CENTER,
             valign = Gtk.Align.CENTER,
             margin_top = 24,
@@ -136,25 +125,24 @@ public class CSSView : Gtk.Box {
             margin_start = 24,
             margin_end = 24,
         };
-        grid.attach (card_label, 0, 0);
-        grid.attach (card, 1, 0, 2);
-        grid.attach (richlist_label, 0, 1);
-        grid.attach (rich_listbox, 1, 1, 2);
-        grid.attach (terminal_label, 0, 2);
-        grid.attach (terminal_scroll, 1, 2, 2);
-        grid.attach (back_button_label, 0, 3);
-        grid.attach (back_button, 1, 3, 2);
-        grid.attach (warmth_label, 0, 4);
-        grid.attach (warmth_scale, 1, 4);
-        grid.attach (temperature_label, 0, 5);
-        grid.attach (temperature_scale, 1, 5);
-        grid.attach (primary_color_label, 0, 6);
-        grid.attach (primary_color_button, 1, 6, 2);
-        grid.attach (accent_color_label, 0, 7);
-        grid.attach (accent_color_grid, 1, 7);
+        box.append (card_header);
+        box.append (card);
+        box.append (richlist_label);
+        box.append (rich_listbox);
+        box.append (terminal_label);
+        box.append (terminal_scroll);
+        box.append (back_button_label);
+        box.append (back_button);
+        box.append (scales_header);
+        box.append (warmth_scale);
+        box.append (temperature_scale);
+        box.append (primary_color_label);
+        box.append (primary_color_button);
+        box.append (accent_color_label);
+        box.append (accent_color_grid);
 
         var scrolled = new Gtk.ScrolledWindow () {
-            child = grid
+            child = box
         };
 
         append (scrolled);

--- a/lib/Widgets/HeaderLabel.vala
+++ b/lib/Widgets/HeaderLabel.vala
@@ -17,7 +17,7 @@ public class Granite.HeaderLabel : Gtk.Widget {
      * Optional secondary label string displayed below the header
      */
     public string? secondary_text {
-        get; construct set; default = null; 
+        get; construct set; default = null;
     }
 
     /**

--- a/lib/Widgets/HeaderLabel.vala
+++ b/lib/Widgets/HeaderLabel.vala
@@ -42,7 +42,7 @@ public class Granite.HeaderLabel : Gtk.Widget {
         var label_widget = new Gtk.Label (label) {
             xalign = 0
         };
-        label_widget.add_css_class (Granite.STYLE_CLASS_H4_LABEL);
+        label_widget.add_css_class ("heading");
         label_widget.set_parent (this);
 
         var secondary_label = new Gtk.Label (secondary_text) {

--- a/lib/Widgets/HeaderLabel.vala
+++ b/lib/Widgets/HeaderLabel.vala
@@ -8,17 +8,29 @@
  * HeaderLabel is a start-aligned {@link Gtk.Label} with the Granite H4 style class
  */
 public class Granite.HeaderLabel : Gtk.Widget {
+
     public string label { get; construct set; }
+
+    public string? body {
+        get; construct set; default = null; 
+    }
 
     /**
      * Create a new HeaderLabel
      */
-    public HeaderLabel (string label) {
-        Object (label: label);
+    public HeaderLabel (string label, string? body = null) {
+        Object (
+            body: body,
+            label: label
+        );
+    }
+
+    class construct {
+        set_css_name ("header");
     }
 
     static construct {
-        set_layout_manager_type (typeof (Gtk.BinLayout));
+        set_layout_manager_type (typeof (Gtk.BoxLayout));
     }
 
     construct {
@@ -28,12 +40,32 @@ public class Granite.HeaderLabel : Gtk.Widget {
         label_widget.add_css_class (Granite.STYLE_CLASS_H4_LABEL);
         label_widget.set_parent (this);
 
+        var body_label = new Gtk.Label (body) {
+            wrap = true,
+            xalign = 0
+        };
+        body_label.add_css_class (Granite.STYLE_CLASS_DIM_LABEL);
+        body_label.add_css_class (Granite.STYLE_CLASS_SMALL_LABEL);
+
         halign = Gtk.Align.START;
+        ((Gtk.BoxLayout) get_layout_manager ()).orientation = Gtk.Orientation.VERTICAL;
 
         bind_property ("label", label_widget, "label");
+
+        notify["body"].connect (() => {
+            body_label.label = body;
+
+            if (body == null || body == "") {
+                body_label.unparent ();
+            } else if (body_label.parent == null) {
+                body_label.set_parent (this);
+            }
+        });
     }
 
     ~HeaderLabel () {
-        get_first_child ().unparent ();
+        while (get_first_child () != null) {
+            get_first_child ().unparent ();
+        }
     }
 }

--- a/lib/Widgets/HeaderLabel.vala
+++ b/lib/Widgets/HeaderLabel.vala
@@ -14,7 +14,6 @@ public class Granite.HeaderLabel : Gtk.Widget {
     public string label { get; construct set; }
 
     private Gtk.Label? secondary_label = null;
-    private string _secondary_text;
     /**
      * Optional secondary label string displayed below the header
      */
@@ -31,7 +30,6 @@ public class Granite.HeaderLabel : Gtk.Widget {
                     secondary_label.label = value;
                 }
             } else if (value != null) {
-                _secondary_text = value;
                 secondary_label = new Gtk.Label (value) {
                     wrap = true,
                     xalign = 0

--- a/lib/Widgets/HeaderLabel.vala
+++ b/lib/Widgets/HeaderLabel.vala
@@ -13,21 +13,42 @@ public class Granite.HeaderLabel : Gtk.Widget {
      */
     public string label { get; construct set; }
 
+    private Gtk.Label secondary_label;
+    private string _secondary_text;
     /**
      * Optional secondary label string displayed below the header
      */
     public string? secondary_text {
-        get; construct set; default = null;
+        get {
+            return _secondary_text;
+        }
+        set {
+            if (secondary_label != null) {
+                if (value == null || value == "") {
+                    secondary_label.unparent ();
+                    secondary_label = null;
+                } else {
+                    secondary_label.label = value;
+                }
+            } else if (value != null) {
+                _secondary_text = value;
+                secondary_label = new Gtk.Label (value) {
+                    wrap = true,
+                    xalign = 0
+                };
+                secondary_label.add_css_class (Granite.STYLE_CLASS_DIM_LABEL);
+                secondary_label.add_css_class (Granite.STYLE_CLASS_SMALL_LABEL);
+
+                secondary_label.set_parent (this);
+            }
+        }
     }
 
     /**
      * Create a new HeaderLabel
      */
-    public HeaderLabel (string label, string? secondary_text = null) {
-        Object (
-            secondary_text: secondary_text,
-            label: label
-        );
+    public HeaderLabel (string label) {
+        Object (label: label);
     }
 
     class construct {
@@ -45,27 +66,10 @@ public class Granite.HeaderLabel : Gtk.Widget {
         label_widget.add_css_class ("heading");
         label_widget.set_parent (this);
 
-        var secondary_label = new Gtk.Label (secondary_text) {
-            wrap = true,
-            xalign = 0
-        };
-        secondary_label.add_css_class (Granite.STYLE_CLASS_DIM_LABEL);
-        secondary_label.add_css_class (Granite.STYLE_CLASS_SMALL_LABEL);
-
         halign = Gtk.Align.START;
         ((Gtk.BoxLayout) get_layout_manager ()).orientation = Gtk.Orientation.VERTICAL;
 
         bind_property ("label", label_widget, "label");
-
-        notify["secondary-text"].connect (() => {
-            secondary_label.label = secondary_text;
-
-            if (secondary_text == null || secondary_text == "") {
-                secondary_label.unparent ();
-            } else if (secondary_label.parent == null) {
-                secondary_label.set_parent (this);
-            }
-        });
     }
 
     ~HeaderLabel () {

--- a/lib/Widgets/HeaderLabel.vala
+++ b/lib/Widgets/HeaderLabel.vala
@@ -57,7 +57,7 @@ public class Granite.HeaderLabel : Gtk.Widget {
 
         bind_property ("label", label_widget, "label");
 
-        notify["secondary_text"].connect (() => {
+        notify["secondary-text"].connect (() => {
             secondary_label.label = secondary_text;
 
             if (secondary_text == null || secondary_text == "") {

--- a/lib/Widgets/HeaderLabel.vala
+++ b/lib/Widgets/HeaderLabel.vala
@@ -8,19 +8,24 @@
  * HeaderLabel is a start-aligned {@link Gtk.Label} with the Granite H4 style class
  */
 public class Granite.HeaderLabel : Gtk.Widget {
-
+    /**
+     * The primary header label string
+     */
     public string label { get; construct set; }
 
-    public string? body {
+    /**
+     * Optional secondary label string displayed below the header
+     */
+    public string? secondary_text {
         get; construct set; default = null; 
     }
 
     /**
      * Create a new HeaderLabel
      */
-    public HeaderLabel (string label, string? body = null) {
+    public HeaderLabel (string label, string? secondary_text = null) {
         Object (
-            body: body,
+            secondary_text: secondary_text,
             label: label
         );
     }
@@ -40,25 +45,25 @@ public class Granite.HeaderLabel : Gtk.Widget {
         label_widget.add_css_class (Granite.STYLE_CLASS_H4_LABEL);
         label_widget.set_parent (this);
 
-        var body_label = new Gtk.Label (body) {
+        var secondary_label = new Gtk.Label (secondary_text) {
             wrap = true,
             xalign = 0
         };
-        body_label.add_css_class (Granite.STYLE_CLASS_DIM_LABEL);
-        body_label.add_css_class (Granite.STYLE_CLASS_SMALL_LABEL);
+        secondary_label.add_css_class (Granite.STYLE_CLASS_DIM_LABEL);
+        secondary_label.add_css_class (Granite.STYLE_CLASS_SMALL_LABEL);
 
         halign = Gtk.Align.START;
         ((Gtk.BoxLayout) get_layout_manager ()).orientation = Gtk.Orientation.VERTICAL;
 
         bind_property ("label", label_widget, "label");
 
-        notify["body"].connect (() => {
-            body_label.label = body;
+        notify["secondary_text"].connect (() => {
+            secondary_label.label = secondary_text;
 
-            if (body == null || body == "") {
-                body_label.unparent ();
-            } else if (body_label.parent == null) {
-                body_label.set_parent (this);
+            if (secondary_text == null || secondary_text == "") {
+                secondary_label.unparent ();
+            } else if (secondary_label.parent == null) {
+                secondary_label.set_parent (this);
             }
         });
     }

--- a/lib/Widgets/HeaderLabel.vala
+++ b/lib/Widgets/HeaderLabel.vala
@@ -13,7 +13,7 @@ public class Granite.HeaderLabel : Gtk.Widget {
      */
     public string label { get; construct set; }
 
-    private Gtk.Label secondary_label;
+    private Gtk.Label? secondary_label = null;
     private string _secondary_text;
     /**
      * Optional secondary label string displayed below the header

--- a/lib/Widgets/HeaderLabel.vala
+++ b/lib/Widgets/HeaderLabel.vala
@@ -20,7 +20,7 @@ public class Granite.HeaderLabel : Gtk.Widget {
      */
     public string? secondary_text {
         get {
-            return _secondary_text;
+            return secondary_label != null ? secondary_label.label : null;
         }
         set {
             if (secondary_label != null) {


### PR DESCRIPTION
As I'm working with more settings panes in particular I'm finding that I want to add description text below certain headers, but because of the built in extra spacing in headers it makes the layout kind of awkard. I'd like to be able to have spacing and sizing kind of specific for this case so we always have nice typography in this kinds of headers:

## BEFORE
![Screenshot from 2022-09-10 16 01 51](https://user-images.githubusercontent.com/7277719/189504599-4bc50355-51b0-45d1-ab15-7aa21eef98e8.png)
![Screenshot from 2022-09-10 16 01 44](https://user-images.githubusercontent.com/7277719/189504601-6769109f-21bd-4e17-ab05-130beb157975.png)

## AFTER
With a little CSS: https://github.com/elementary/stylesheet/pull/1228

![Screenshot from 2022-09-10 16 14 28](https://user-images.githubusercontent.com/7277719/189504830-4bd3095d-ba7d-4896-a4b8-de05ce06d9f0.png)
