### PR TITLE
SettingsSidebarRow.vala - Fix status label showing but empty

### DIFF
--- a/lib/Widgets/SettingsSidebarRow.vala
+++ b/lib/Widgets/SettingsSidebarRow.vala
@@ -49,7 +49,6 @@ private class Granite.SettingsSidebarRow : Gtk.ListBoxRow {
         set {
             status_label.label = value;
             status_label.visible = true;
-            status_label.show ();
         }
     }
 

--- a/lib/Widgets/SettingsSidebarRow.vala
+++ b/lib/Widgets/SettingsSidebarRow.vala
@@ -48,6 +48,7 @@ private class Granite.SettingsSidebarRow : Gtk.ListBoxRow {
     public string status {
         set {
             status_label.label = value;
+            status_label.visible = true;
             status_label.show ();
         }
     }
@@ -91,7 +92,8 @@ private class Granite.SettingsSidebarRow : Gtk.ListBoxRow {
             use_markup = true,
             ellipsize = Pango.EllipsizeMode.END,
             vexpand = true,
-            xalign = 0
+            xalign = 0,
+            visible = false
         };
         status_label.add_css_class (Granite.STYLE_CLASS_SMALL_LABEL);
 


### PR DESCRIPTION
This fixes the weird empty space below a SettingsSidebarRow's title when there's no status string set.
That way, the options in e.g. the Mouse switchboard plug don't have the weird empty "description" space.

|Before|After|
|:---:|:---:|
|![Screenshot from 2022-10-05 11 40 43](https://user-images.githubusercontent.com/4886639/194088750-bf0c54f9-c323-4927-99e0-b67d84607ce6.png)|![Screenshot from 2022-10-05 11 39 45](https://user-images.githubusercontent.com/4886639/194088525-17df55f2-c6ac-471e-9cfb-ec05a0e268e1.png)|