### PR TITLE
Fix build with newer Vala

### DIFF
--- a/demo/Views/UtilsView.vala
+++ b/demo/Views/UtilsView.vala
@@ -73,7 +73,11 @@ public class UtilsView : Gtk.Grid {
             Granite.contrasting_foreground_color (bg_color).to_string ()
         );
 
+#if VALA_0_58
+        provider.load_from_data (css);
+#else
         provider.load_from_data ((uint8[])css);
+#endif
         demo_label_style_context.add_provider (
             provider,
             Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION

--- a/lib/Widgets/Utils.vala
+++ b/lib/Widgets/Utils.vala
@@ -263,7 +263,11 @@ namespace Granite.Widgets.Utils {
         var css = "@define-color color_primary %s;".printf (color.to_string ());
 
         var css_provider = new Gtk.CssProvider ();
+#if VALA_0_58
+        css_provider.load_from_data (css);
+#else
         css_provider.load_from_data (css.data);
+#endif
 
         Gtk.StyleContext.add_provider_for_display (Gdk.Display.get_default (), css_provider, priority);
 


### PR DESCRIPTION
Gtk.CssProvider.load_from_data() takes a string instead of uint8[] now.