### PR TITLE
settings: remove inappropriate ownership annotation

### DIFF
--- a/lib/Widgets/Settings.vala
+++ b/lib/Widgets/Settings.vala
@@ -6,7 +6,7 @@
 namespace Granite {
     [DBus (name = "io.elementary.pantheon.AccountsService")]
     private interface Pantheon.AccountsService : Object {
-        public abstract int prefers_color_scheme { owned get; set; }
+        public abstract int prefers_color_scheme { get; set; }
     }
 
     [DBus (name = "org.freedesktop.Accounts")]


### PR DESCRIPTION
It doesn't make sense for an int property to be owned because ints are not heap-allocated. This should fix build with latest vala.

Fixes #641