### PR TITLE
Fix demo desktop file

### DIFF
--- a/demo/io.elementary.granite-7.demo.desktop
+++ b/demo/io.elementary.granite-7.demo.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=Granite 7 Demo
 Comment=A demo of the Granite toolkit
-Exec=granite-demo
+Exec=granite-7-demo
 Icon=io.elementary.granite-7
 Type=Application
 NoDisplay=true

--- a/demo/io.elementary.granite-7.demo.desktop
+++ b/demo/io.elementary.granite-7.demo.desktop
@@ -5,4 +5,4 @@ Exec=granite-7-demo
 Icon=io.elementary.granite-7
 Type=Application
 NoDisplay=true
-StartupWMClass=granite-demo
+StartupWMClass=granite-7-demo


### PR DESCRIPTION
meson installs as `granite-7-demo`:

```meson
executable(
    'granite-7-demo',

    'GraniteDemo.vala',

    'Views/AccelLabelView.vala',
    'Views/ApplicationView.vala',
    'Views/CSSView.vala',
    'Views/DateTimePickerView.vala',
    'Views/DialogsView.vala',
    'Views/FormView.vala',
    'Views/HyperTextViewGrid.vala',
    'Views/ModeButtonView.vala',
    'Views/OverlayBarView.vala',
    'Views/SettingsView/SettingsPage.vala',
    'Views/SettingsView/SettingsView.vala',
    'Views/SettingsView/SimpleSettingsPage.vala',
    'Views/ToastView.vala',
    'Views/UtilsView.vala',
    'Views/WelcomeView.vala',

    dependencies: [libgranite_dep],

    install: true,
)
```