### PR TITLE
Settings Urls

### DIFF
--- a/demo/GraniteDemo.vala
+++ b/demo/GraniteDemo.vala
@@ -21,7 +21,7 @@ public class Granite.Demo : Gtk.Application {
         var overlaybar_view = new OverlayBarView ();
         var settings_view = new SettingsView ();
         var toast_view = new ToastView ();
-        var settings_urls_view = new SettingsUrlsView ();
+        var settings_uris_view = new SettingsUrisView ();
         var utils_view = new UtilsView ();
         var placeholder = new WelcomeView ();
         var dialogs_view = new DialogsView (window);
@@ -37,7 +37,7 @@ public class Granite.Demo : Gtk.Application {
         main_stack.add_titled (mode_button_view, "selection_controls", "Selection Controls");
         main_stack.add_titled (overlaybar_view, "overlaybar", "OverlayBar");
         main_stack.add_titled (settings_view, "settings", "SettingsSidebar");
-        main_stack.add_titled (settings_urls_view, "settings_urls", "Settings URLs");
+        main_stack.add_titled (settings_uris_view, "settings_uris", "Settings URIs");
         main_stack.add_titled (toast_view, "toasts", "Toast");
         main_stack.add_titled (utils_view, "utils", "Utils");
         main_stack.add_titled (dialogs_view, "dialogs", "Dialogs");

--- a/demo/GraniteDemo.vala
+++ b/demo/GraniteDemo.vala
@@ -21,6 +21,7 @@ public class Granite.Demo : Gtk.Application {
         var overlaybar_view = new OverlayBarView ();
         var settings_view = new SettingsView ();
         var toast_view = new ToastView ();
+        var settings_urls_view = new SettingsUrlsView ();
         var utils_view = new UtilsView ();
         var placeholder = new WelcomeView ();
         var dialogs_view = new DialogsView (window);
@@ -36,6 +37,7 @@ public class Granite.Demo : Gtk.Application {
         main_stack.add_titled (mode_button_view, "selection_controls", "Selection Controls");
         main_stack.add_titled (overlaybar_view, "overlaybar", "OverlayBar");
         main_stack.add_titled (settings_view, "settings", "SettingsSidebar");
+        main_stack.add_titled (settings_urls_view, "settings_urls", "Settings URLs");
         main_stack.add_titled (toast_view, "toasts", "Toast");
         main_stack.add_titled (utils_view, "utils", "Utils");
         main_stack.add_titled (dialogs_view, "dialogs", "Dialogs");

--- a/demo/Views/SettingsUrisView.vala
+++ b/demo/Views/SettingsUrisView.vala
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 
-public class SettingsUrlsView : Gtk.Box {
+public class SettingsUrisView : Gtk.Box {
     construct {
         halign = Gtk.Align.CENTER;
 

--- a/demo/Views/SettingsUrlsView.vala
+++ b/demo/Views/SettingsUrlsView.vala
@@ -7,95 +7,50 @@ public class SettingsUrlsView : Gtk.Box {
     construct {
         halign = Gtk.Align.CENTER;
 
-        var flow = new Gtk.FlowBox () {
+        var column = new Gtk.Box (Gtk.Orientation.VERTICAL, 16) {
             margin_start = 24,
             margin_end = 24,
             margin_top = 24,
             margin_bottom = 24,
             halign = Gtk.Align.CENTER,
-            valign = Gtk.Align.CENTER,
-            selection_mode = Gtk.SelectionMode.NONE,
-            homogeneous = true,
-            min_children_per_line = 3,
-            column_spacing = 8,
-            row_spacing = 16
+            valign = Gtk.Align.CENTER
         };
 
-        flow.append (new Gtk.LinkButton.with_label (
-            Granite.LINK_SETTINGS_APPLICATIONS_DEFAULTS,
-            _("Applications → Defaults")
-        ));
-
-        flow.append (new Gtk.LinkButton.with_label (
-            Granite.LINK_SETTINGS_APPLICATIONS_STARTUP,
-            _("Applications → Startup")
-        ));
-
-        flow.append (new Gtk.LinkButton.with_label (
-            Granite.LINK_SETTINGS_APPLICATIONS_PERMISSIONS,
-            _("Applications → Permissions")
-        ));
-
-        flow.append (new Gtk.LinkButton.with_label (
-            Granite.LINK_SETTINGS_DESKTOP_APPEARANCE_WALLPAPER,
-            _("Desktop → Wallpaper")
-        ));
-
-        flow.append (new Gtk.LinkButton.with_label (
-            Granite.LINK_SETTINGS_DESKTOP_APPEARANCE,
-            _("Desktop → Appearance")
-        ));
-
-        flow.append (new Gtk.LinkButton.with_label (
-            Granite.LINK_SETTINGS_DESKTOP_TEXT,
-            _("Desktop → Text")
-        ));
-
-        flow.append (new Gtk.LinkButton.with_label (
-            Granite.LINK_SETTINGS_DESKTOP_DOCK,
-            _("Desktop → Dock & Panel")
-        ));
-
-        flow.append (new Gtk.LinkButton.with_label (
-            Granite.LINK_SETTINGS_DESKTOP_MULTITASKING,
-            _("Desktop → Multitasking")
-        ));
-
-        flow.append (new Gtk.LinkButton.with_label (
-            Granite.LINK_SETTINGS_LANGUAGE,
-            _("Language & Region")
-        ));
-
-        flow.append (new Gtk.LinkButton.with_label (
-            Granite.LINK_SETTINGS_NOTIFICATIONS,
-            _("Notifications")
-        ));
-
-        flow.append (new Gtk.LinkButton.with_label (
-            Granite.LINK_SETTINGS_PRIVACY,
-            _("Security & Privacy → History")
-        ));
-
-        flow.append (new Gtk.LinkButton.with_label (
-            Granite.LINK_SETTINGS_SECURITY_LOCKING,
-            _("Security & Privacy → Locking")
-        ));
-
-        flow.append (new Gtk.LinkButton.with_label (
-            Granite.LINK_SETTINGS_SECURITY_FIREWALL,
-            _("Security & Privacy → Firewall")
-        ));
-
-        flow.append (new Gtk.LinkButton.with_label (
-            Granite.LINK_SETTINGS_PRIVACY_TRASH,
-            _("Security & Privacy → Housekeeping")
-        ));
-
-        flow.append (new Gtk.LinkButton.with_label (
-            Granite.LINK_SETTINGS_PRIVACY_LOCATION,
+        column.append (new Gtk.LinkButton.with_label (
+            Granite.SettingsUri.LOCATION,
             _("Security & Privacy → Location Services")
         ));
 
-        append (flow);
+        column.append (new Gtk.LinkButton.with_label (
+            Granite.SettingsUri.ONLINE_ACCOUNTS,
+            _("Online Accounts")
+        ));
+
+        column.append (new Gtk.LinkButton.with_label (
+            Granite.SettingsUri.NETWORK,
+            _("Network")
+        ));
+
+        column.append (new Gtk.LinkButton.with_label (
+            Granite.SettingsUri.PERMISSIONS,
+            _("Applications → Permissions")
+        ));
+
+        column.append (new Gtk.LinkButton.with_label (
+            Granite.SettingsUri.NOTIFICATIONS,
+            _("Notifications")
+        ));
+
+        column.append (new Gtk.LinkButton.with_label (
+            Granite.SettingsUri.SOUND_INPUT,
+            _("Sound → Input")
+        ));
+
+        column.append (new Gtk.LinkButton.with_label (
+            Granite.SettingsUri.SHORTCUTS,
+            _("Keyboard → Shortcuts → Custom")
+        ));
+
+        append (column);
     }
 }

--- a/demo/Views/SettingsUrlsView.vala
+++ b/demo/Views/SettingsUrlsView.vala
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2011-2023 elementary, Inc. (https://elementary.io)
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+public class SettingsUrlsView : Gtk.Box {
+    construct {
+        halign = Gtk.Align.CENTER;
+
+        var flow = new Gtk.FlowBox () {
+            margin_start = 24,
+            margin_end = 24,
+            margin_top = 24,
+            margin_bottom = 24,
+            halign = Gtk.Align.CENTER,
+            valign = Gtk.Align.CENTER,
+            selection_mode = Gtk.SelectionMode.NONE,
+            homogeneous = true,
+            min_children_per_line = 3,
+            column_spacing = 8,
+            row_spacing = 16
+        };
+
+        flow.append (new Gtk.LinkButton.with_label (
+            Granite.LINK_SETTINGS_APPLICATIONS_DEFAULTS,
+            _("Applications → Defaults")
+        ));
+
+        flow.append (new Gtk.LinkButton.with_label (
+            Granite.LINK_SETTINGS_APPLICATIONS_STARTUP,
+            _("Applications → Startup")
+        ));
+
+        flow.append (new Gtk.LinkButton.with_label (
+            Granite.LINK_SETTINGS_APPLICATIONS_PERMISSIONS,
+            _("Applications → Permissions")
+        ));
+
+        flow.append (new Gtk.LinkButton.with_label (
+            Granite.LINK_SETTINGS_DESKTOP_APPEARANCE_WALLPAPER,
+            _("Desktop → Wallpaper")
+        ));
+
+        flow.append (new Gtk.LinkButton.with_label (
+            Granite.LINK_SETTINGS_DESKTOP_APPEARANCE,
+            _("Desktop → Appearance")
+        ));
+
+        flow.append (new Gtk.LinkButton.with_label (
+            Granite.LINK_SETTINGS_DESKTOP_TEXT,
+            _("Desktop → Text")
+        ));
+
+        flow.append (new Gtk.LinkButton.with_label (
+            Granite.LINK_SETTINGS_DESKTOP_DOCK,
+            _("Desktop → Dock & Panel")
+        ));
+
+        flow.append (new Gtk.LinkButton.with_label (
+            Granite.LINK_SETTINGS_DESKTOP_MULTITASKING,
+            _("Desktop → Multitasking")
+        ));
+
+        flow.append (new Gtk.LinkButton.with_label (
+            Granite.LINK_SETTINGS_LANGUAGE,
+            _("Language & Region")
+        ));
+
+        flow.append (new Gtk.LinkButton.with_label (
+            Granite.LINK_SETTINGS_NOTIFICATIONS,
+            _("Notifications")
+        ));
+
+        flow.append (new Gtk.LinkButton.with_label (
+            Granite.LINK_SETTINGS_PRIVACY,
+            _("Security & Privacy → History")
+        ));
+
+        flow.append (new Gtk.LinkButton.with_label (
+            Granite.LINK_SETTINGS_SECURITY_LOCKING,
+            _("Security & Privacy → Locking")
+        ));
+
+        flow.append (new Gtk.LinkButton.with_label (
+            Granite.LINK_SETTINGS_SECURITY_FIREWALL,
+            _("Security & Privacy → Firewall")
+        ));
+
+        flow.append (new Gtk.LinkButton.with_label (
+            Granite.LINK_SETTINGS_PRIVACY_TRASH,
+            _("Security & Privacy → Housekeeping")
+        ));
+
+        flow.append (new Gtk.LinkButton.with_label (
+            Granite.LINK_SETTINGS_PRIVACY_LOCATION,
+            _("Security & Privacy → Location Services")
+        ));
+
+        append (flow);
+    }
+}

--- a/demo/meson.build
+++ b/demo/meson.build
@@ -12,7 +12,7 @@ executable(
     'Views/HyperTextViewGrid.vala',
     'Views/ModeButtonView.vala',
     'Views/OverlayBarView.vala',
-    'Views/SettingsUrlsView.vala',
+    'Views/SettingsUrisView.vala',
     'Views/SettingsView/SettingsPage.vala',
     'Views/SettingsView/SettingsView.vala',
     'Views/SettingsView/SimpleSettingsPage.vala',

--- a/demo/meson.build
+++ b/demo/meson.build
@@ -12,6 +12,7 @@ executable(
     'Views/HyperTextViewGrid.vala',
     'Views/ModeButtonView.vala',
     'Views/OverlayBarView.vala',
+    'Views/SettingsUrlsView.vala',
     'Views/SettingsView/SettingsPage.vala',
     'Views/SettingsView/SettingsView.vala',
     'Views/SettingsView/SimpleSettingsPage.vala',

--- a/lib/Constants.vala
+++ b/lib/Constants.vala
@@ -184,78 +184,44 @@ namespace Granite {
     public const int TRANSITION_DURATION_OPEN = 250;
 
     /**
-    * Link to open Applications → Defaults settings page
+    * Deep links to specific Settings pages.
     */
-    public const string LINK_SETTINGS_APPLICATIONS_DEFAULTS = "settings://applications/defaults";
+    namespace SettingsUri {
 
-    /**
-    * Link to open Applications → Startup settings page
-    */
-    public const string LINK_SETTINGS_APPLICATIONS_STARTUP = "settings://applications/startup";
+         /**
+         * Link to open Security & Privacy → Location Services settings page
+         */
+         public const string LOCATION = "settings://privacy/location";
 
-    /**
-    * Link to open Applications → Permissions settings page
-    */
-    public const string LINK_SETTINGS_APPLICATIONS_PERMISSIONS = "settings://applications/permissions";
+         /**
+         * Link to open Online Accounts settings page
+         */
+         public const string ONLINE_ACCOUNTS = "settings://accounts/online";
 
-    /**
-    * Link to open Desktop → Wallpaper settings page
-    */
-    public const string LINK_SETTINGS_DESKTOP_APPEARANCE_WALLPAPER = "settings://desktop/appearance/wallpaper";
+         /**
+         * Link to Network settings page
+         */
+         public const string NETWORK = "settings://network";
 
-    /**
-    * Link to open Desktop → Appearance settings page
-    */
-    public const string LINK_SETTINGS_DESKTOP_APPEARANCE = "settings://desktop/appearance";
+         /**
+         * Link to open Applications → Permissions settings page
+         */
+         public const string PERMISSIONS = "settings://applications/permissions";
 
-    /**
-    * Link to open Desktop → Dock & Panel settings page
-    */
-    public const string LINK_SETTINGS_DESKTOP_DOCK = "settings://desktop/dock";
+         /**
+         * Link to open Notifications settings page
+         */
+         public const string NOTIFICATIONS = "settings://notifications";
 
-    /**
-    * Link to open Desktop → Multitasking settings page
-    */
-    public const string LINK_SETTINGS_DESKTOP_MULTITASKING = "settings://desktop/multitasking";
+        /**
+        * Link to open Sound → Input settings page
+        */
+        public const string SOUND_INPUT = "settings://sound/input";
 
-    /**
-    * Link to open Desktop → Text settings page
-    */
-    public const string LINK_SETTINGS_DESKTOP_TEXT = "settings://desktop/text";
+        /**
+        * Link to open Keyboard → Shortcuts → Custom settings page
+        */
+        public const string SHORTCUTS = "settings://input/keyboard/shortcuts/custom";
 
-    /**
-    * Link to open Language & Region settings page
-    */
-    public const string LINK_SETTINGS_LANGUAGE = "settings://language";
-
-    /**
-    * Link to open Notifications settings page
-    */
-    public const string LINK_SETTINGS_NOTIFICATIONS = "settings://notifications";
-
-    /**
-    * Link to open Security & Privacy → History settings page
-    */
-    public const string LINK_SETTINGS_PRIVACY = "settings://privacy";
-
-    /**
-    * Link to open Security & Privacy → Location Services settings page
-    */
-    public const string LINK_SETTINGS_PRIVACY_LOCATION = "settings://privacy/location";
-
-    /**
-    * Link to open Security & Privacy → Housekeeping settings page
-    */
-    public const string LINK_SETTINGS_PRIVACY_TRASH = "settings://privacy/trash";
-
-    /**
-    * Link to open Security & Privacy → Firewall settings page
-    */
-    public const string LINK_SETTINGS_SECURITY_FIREWALL = "settings://security/firewall";
-
-    /**
-    * Link to open Security & Privacy → Locking settings page
-    */
-    public const string LINK_SETTINGS_SECURITY_LOCKING = "settings://security/locking";
-
+    }
 }

--- a/lib/Constants.vala
+++ b/lib/Constants.vala
@@ -182,4 +182,80 @@ namespace Granite {
      * Transition duration when a widget opens, reveals more content, or enters the screen
      */
     public const int TRANSITION_DURATION_OPEN = 250;
+
+    /**
+    * Link to open Applications → Defaults settings page
+    */
+    public const string LINK_SETTINGS_APPLICATIONS_DEFAULTS = "settings://applications/defaults";
+
+    /**
+    * Link to open Applications → Startup settings page
+    */
+    public const string LINK_SETTINGS_APPLICATIONS_STARTUP = "settings://applications/startup";
+
+    /**
+    * Link to open Applications → Permissions settings page
+    */
+    public const string LINK_SETTINGS_APPLICATIONS_PERMISSIONS = "settings://applications/permissions";
+
+    /**
+    * Link to open Desktop → Wallpaper settings page
+    */
+    public const string LINK_SETTINGS_DESKTOP_APPEARANCE_WALLPAPER = "settings://desktop/appearance/wallpaper";
+
+    /**
+    * Link to open Desktop → Appearance settings page
+    */
+    public const string LINK_SETTINGS_DESKTOP_APPEARANCE = "settings://desktop/appearance";
+
+    /**
+    * Link to open Desktop → Dock & Panel settings page
+    */
+    public const string LINK_SETTINGS_DESKTOP_DOCK = "settings://desktop/dock";
+
+    /**
+    * Link to open Desktop → Multitasking settings page
+    */
+    public const string LINK_SETTINGS_DESKTOP_MULTITASKING = "settings://desktop/multitasking";
+
+    /**
+    * Link to open Desktop → Text settings page
+    */
+    public const string LINK_SETTINGS_DESKTOP_TEXT = "settings://desktop/text";
+
+    /**
+    * Link to open Language & Region settings page
+    */
+    public const string LINK_SETTINGS_LANGUAGE = "settings://language";
+
+    /**
+    * Link to open Notifications settings page
+    */
+    public const string LINK_SETTINGS_NOTIFICATIONS = "settings://notifications";
+
+    /**
+    * Link to open Security & Privacy → History settings page
+    */
+    public const string LINK_SETTINGS_PRIVACY = "settings://privacy";
+
+    /**
+    * Link to open Security & Privacy → Location Services settings page
+    */
+    public const string LINK_SETTINGS_PRIVACY_LOCATION = "settings://privacy/location";
+
+    /**
+    * Link to open Security & Privacy → Housekeeping settings page
+    */
+    public const string LINK_SETTINGS_PRIVACY_TRASH = "settings://privacy/trash";
+
+    /**
+    * Link to open Security & Privacy → Firewall settings page
+    */
+    public const string LINK_SETTINGS_SECURITY_FIREWALL = "settings://security/firewall";
+
+    /**
+    * Link to open Security & Privacy → Locking settings page
+    */
+    public const string LINK_SETTINGS_SECURITY_LOCKING = "settings://security/locking";
+
 }


### PR DESCRIPTION
Implements the Granite part of [Settings Urls #190](https://github.com/elementary/docs/issues/190) issue from the docs repo.

Currently covers:
- Location Services
- Online Accounts
- Network
- App Permissions
- Notifications
- Sound Input
- Custom Shortcuts

Links are showcased in a new demo app view as links:

![Screenshot from 2023-05-11 21 56 29](https://github.com/elementary/granite/assets/5374391/a39d2122-3dbf-4a5d-b11a-42edeb61242f)

