### PR TITLE
Fix build with latest Vala 0.56.x

### DIFF
--- a/demo/Views/UtilsView.vala
+++ b/demo/Views/UtilsView.vala
@@ -73,8 +73,8 @@ public class UtilsView : Gtk.Grid {
             Granite.contrasting_foreground_color (bg_color).to_string ()
         );
 
-#if VALA_0_58
-        provider.load_from_data (css);
+#if HAS_VALA_0_56_11
+        provider.load_from_data (css, -1);
 #else
         provider.load_from_data ((uint8[])css);
 #endif

--- a/lib/Widgets/Utils.vala
+++ b/lib/Widgets/Utils.vala
@@ -263,8 +263,8 @@ namespace Granite.Widgets.Utils {
         var css = "@define-color color_primary %s;".printf (color.to_string ());
 
         var css_provider = new Gtk.CssProvider ();
-#if VALA_0_58
-        css_provider.load_from_data (css);
+#if HAS_VALA_0_56_11
+        css_provider.load_from_data (css, -1);
 #else
         css_provider.load_from_data (css.data);
 #endif

--- a/meson.build
+++ b/meson.build
@@ -28,6 +28,10 @@ else
     vala_os_arg = []
 endif
 
+if meson.get_compiler('vala').version().version_compare('>=0.56.11')
+    vala_os_arg += ['--define=HAS_VALA_0_56_11']
+endif
+
 glib_min_version = '2.50'
 if build_machine.system() == 'windows'
     gio_os_dep = dependency('gio-windows-2.0', version: '>=' + glib_min_version)


### PR DESCRIPTION
Previously #637. With [vala@bac7c570](https://gitlab.gnome.org/GNOME/vala/-/commit/bac7c570dccb056e917aef93b4343382be2aef34) the failure is now on 0.56.x as well.

```
../lib/Widgets/Utils.vala:269.38-269.45: error: Argument 1: Cannot convert from `unowned uint8[]' to `unowned string'
  269 |         css_provider.load_from_data (css.data);
      |                                      ^~~~~~~~  
../lib/Widgets/Utils.vala:269.9-269.46: error: 1 missing arguments for `void Gtk.CssProvider.load_from_data (string, ssize_t)'
  269 |         css_provider.load_from_data (css.data);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
```