### PR TITLE
Replace Gtk.Widget.get_style_context deprecated in Gtk 4.10

### DIFF
--- a/demo/GraniteDemo.vala
+++ b/demo/GraniteDemo.vala
@@ -74,7 +74,7 @@ public class Granite.Demo : Gtk.Application {
         gtk_settings.gtk_application_prefer_dark_theme = granite_settings.prefers_color_scheme == Granite.Settings.ColorScheme.DARK;
 
         var headerbar = new Gtk.HeaderBar ();
-        headerbar.get_style_context ().add_class ("default-decoration");
+        headerbar.add_css_class ("default-decoration");
         headerbar.show_title_buttons = true;
         headerbar.pack_end (mode_switch);
 

--- a/demo/Views/CSSView.vala
+++ b/demo/Views/CSSView.vala
@@ -16,18 +16,18 @@ public class CSSView : Gtk.Box {
             margin_start = 24,
             margin_top = 12
         };
-        header1.get_style_context ().add_class (Granite.STYLE_CLASS_H1_LABEL);
+        header1.add_css_class (Granite.STYLE_CLASS_H1_LABEL);
 
         var header2 = new Gtk.Label ("\"h2\" Style Class");
-        header2.get_style_context ().add_class (Granite.STYLE_CLASS_H2_LABEL);
+        header2.add_css_class (Granite.STYLE_CLASS_H2_LABEL);
 
         var header3 = new Gtk.Label ("\"h3\" Style Class");
-        header3.get_style_context ().add_class (Granite.STYLE_CLASS_H3_LABEL);
+        header3.add_css_class (Granite.STYLE_CLASS_H3_LABEL);
 
         var header4 = new Gtk.Label ("\"h4\" Style Class") {
             margin_bottom = 12
         };
-        header4.get_style_context ().add_class (Granite.STYLE_CLASS_H4_LABEL);
+        header4.add_css_class (Granite.STYLE_CLASS_H4_LABEL);
 
         var card_header = new Granite.HeaderLabel ("Cards and Headers") {
             secondary_text = "\"card\" with \"rounded\" and \"checkerboard\" style classes"
@@ -75,7 +75,7 @@ public class CSSView : Gtk.Box {
         var back_button = new Gtk.Button.with_label ("Back Button") {
             halign = Gtk.Align.START
         };
-        back_button.get_style_context ().add_class (Granite.STYLE_CLASS_BACK_BUTTON);
+        back_button.add_css_class (Granite.STYLE_CLASS_BACK_BUTTON);
 
         var scales_header = new Granite.HeaderLabel ("Scales") {
             secondary_text = "\"warmth\" and \"temperature\" style classes"
@@ -88,7 +88,7 @@ public class CSSView : Gtk.Box {
             inverted = true
         };
         warmth_scale.set_value (6000);
-        warmth_scale.get_style_context ().add_class (Granite.STYLE_CLASS_WARMTH);
+        warmth_scale.add_css_class (Granite.STYLE_CLASS_WARMTH);
 
         var temperature_scale = new Gtk.Scale.with_range (Gtk.Orientation.HORIZONTAL, -16.0f, 16.0f, 1.0) {
             draw_value = false,
@@ -96,7 +96,7 @@ public class CSSView : Gtk.Box {
             hexpand = true
         };
         temperature_scale.set_value (0);
-        temperature_scale.get_style_context ().add_class (Granite.STYLE_CLASS_TEMPERATURE);
+        temperature_scale.add_css_class (Granite.STYLE_CLASS_TEMPERATURE);
 
         var primary_color_label = new Granite.HeaderLabel ("Set HeaderBar color");
 
@@ -105,10 +105,10 @@ public class CSSView : Gtk.Box {
         var accent_color_label = new Granite.HeaderLabel ("Accent colored labels and icons");
 
         var accent_color_icon = new Gtk.Image.from_icon_name ("emoji-body-symbolic");
-        accent_color_icon.get_style_context ().add_class (Granite.STYLE_CLASS_ACCENT);
+        accent_color_icon.add_css_class (Granite.STYLE_CLASS_ACCENT);
 
         var accent_color_string = new Gtk.Label ("Lorem ipsum dolor sit amet");
-        accent_color_string.get_style_context ().add_class (Granite.STYLE_CLASS_ACCENT);
+        accent_color_string.add_css_class (Granite.STYLE_CLASS_ACCENT);
 
         var accent_color_grid = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 6);
         accent_color_grid.append (accent_color_icon);

--- a/demo/Views/DateTimePickerView.vala
+++ b/demo/Views/DateTimePickerView.vala
@@ -11,7 +11,7 @@ public class DateTimePickerView : Gtk.Grid {
     construct {
         var pickers_label = new Gtk.Label ("Picker Widgets");
         pickers_label.xalign = 0;
-        pickers_label.get_style_context ().add_class (Granite.STYLE_CLASS_H4_LABEL);
+        pickers_label.add_css_class (Granite.STYLE_CLASS_H4_LABEL);
 
         var date_label = new Gtk.Label ("DatePicker:");
         date_label.halign = Gtk.Align.END;
@@ -26,7 +26,7 @@ public class DateTimePickerView : Gtk.Grid {
         var formatting_label = new Gtk.Label ("String Formatting");
         formatting_label.margin_top = 6;
         formatting_label.xalign = 0;
-        formatting_label.get_style_context ().add_class (Granite.STYLE_CLASS_H4_LABEL);
+        formatting_label.add_css_class (Granite.STYLE_CLASS_H4_LABEL);
 
         var current_time_label = new Gtk.Label ("Localized time:");
         current_time_label.halign = Gtk.Align.END;

--- a/demo/Views/DialogsView.vala
+++ b/demo/Views/DialogsView.vala
@@ -61,7 +61,7 @@ public class DialogsView : Gtk.Box {
         dialog.add_button ("Cancel", Gtk.ResponseType.CANCEL);
 
         var suggested_button = dialog.add_button ("Suggested Action", Gtk.ResponseType.ACCEPT);
-        suggested_button.get_style_context ().add_class (Granite.STYLE_CLASS_SUGGESTED_ACTION);
+        suggested_button.add_css_class (Granite.STYLE_CLASS_SUGGESTED_ACTION);
 
         dialog.response.connect ((response_id) => {
            if (response_id == Gtk.ResponseType.ACCEPT) {
@@ -85,7 +85,7 @@ public class DialogsView : Gtk.Box {
         message_dialog.transient_for = window;
 
         var suggested_button = new Gtk.Button.with_label ("Suggested Action");
-        suggested_button.get_style_context ().add_class (Granite.STYLE_CLASS_SUGGESTED_ACTION);
+        suggested_button.add_css_class (Granite.STYLE_CLASS_SUGGESTED_ACTION);
         message_dialog.add_action_widget (suggested_button, Gtk.ResponseType.ACCEPT);
 
         var custom_widget = new Gtk.CheckButton.with_label ("Custom widget");

--- a/demo/Views/FormView.vala
+++ b/demo/Views/FormView.vala
@@ -16,7 +16,7 @@ public class FormView : Gtk.Box {
             halign = Gtk.Align.START,
             xalign = 0
         };
-        username_label.get_style_context ().add_class (Granite.STYLE_CLASS_H4_LABEL);
+        username_label.add_css_class (Granite.STYLE_CLASS_H4_LABEL);
 
         var username_entry = new Granite.ValidatedEntry () {
             min_length = 8,

--- a/demo/Views/HyperTextViewGrid.vala
+++ b/demo/Views/HyperTextViewGrid.vala
@@ -23,7 +23,7 @@ public class HyperTextViewGrid : Gtk.Box {
             halign = Gtk.Align.START,
             xalign = 0
         };
-        hypertext_label.get_style_context ().add_class (Granite.STYLE_CLASS_H4_LABEL);
+        hypertext_label.add_css_class (Granite.STYLE_CLASS_H4_LABEL);
 
         var hypertext_textview = new Granite.HyperTextView ();
         hypertext_textview.buffer.text = "elementary OS - https://elementary.io/\nThe fast, open and privacy-respecting replacement for Windows and macOS.";

--- a/demo/Views/ModeButtonView.vala
+++ b/demo/Views/ModeButtonView.vala
@@ -8,7 +8,7 @@ public class ModeButtonView : Gtk.Box {
         var mode_switch_label = new Gtk.Label ("ModeSwitch");
         mode_switch_label.halign = Gtk.Align.START;
         mode_switch_label.margin_top = 12;
-        mode_switch_label.get_style_context ().add_class (Granite.STYLE_CLASS_H4_LABEL);
+        mode_switch_label.add_css_class (Granite.STYLE_CLASS_H4_LABEL);
 
         var mode_switch = new Granite.ModeSwitch.from_icon_name (
             "display-brightness-symbolic",
@@ -23,10 +23,10 @@ public class ModeButtonView : Gtk.Box {
             halign = Gtk.Align.START,
             xalign = 0,
         };
-        switchbutton_header.get_style_context ().add_class (Granite.STYLE_CLASS_H4_LABEL);
+        switchbutton_header.add_css_class (Granite.STYLE_CLASS_H4_LABEL);
 
         var header_switchmodelbutton = new Granite.SwitchModelButton ("Header");
-        header_switchmodelbutton.get_style_context ().add_class (Granite.STYLE_CLASS_H4_LABEL);
+        header_switchmodelbutton.add_css_class (Granite.STYLE_CLASS_H4_LABEL);
 
         var switchmodelbutton = new Granite.SwitchModelButton ("Default");
 

--- a/lib/Widgets/AccelLabel.vala
+++ b/lib/Widgets/AccelLabel.vala
@@ -106,9 +106,7 @@ public class Granite.AccelLabel : Gtk.Box {
                     continue;
                 }
                 var accel_label = new Gtk.Label (accel);
-
-                var accel_label_context = accel_label.get_style_context ();
-                accel_label_context.add_class (Granite.STYLE_CLASS_KEYCAP);
+                accel_label.add_css_class (Granite.STYLE_CLASS_KEYCAP);
 
                 append (accel_label);
             }

--- a/lib/Widgets/Dialog.vala
+++ b/lib/Widgets/Dialog.vala
@@ -43,7 +43,7 @@
 *   dialog.add_button ("Cancel", Gtk.ResponseType.CANCEL);
 *
 *   var suggested_button = dialog.add_button ("Suggested Action", Gtk.ResponseType.ACCEPT);
-*   suggested_button.get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
+*   suggested_button.add_css_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
 *
 *   dialog.show_all ();
 *   dialog.response.connect ((response_id) => {

--- a/lib/Widgets/ModeSwitch.vala
+++ b/lib/Widgets/ModeSwitch.vala
@@ -88,7 +88,7 @@ public class Granite.ModeSwitch : Gtk.Box {
 
         var mode_switch = new Gtk.Switch ();
         mode_switch.valign = Gtk.Align.CENTER;
-        mode_switch.get_style_context ().add_class (Granite.STYLE_CLASS_MODE_SWITCH);
+        mode_switch.add_css_class (Granite.STYLE_CLASS_MODE_SWITCH);
 
         var secondary_click_controller = new Gtk.GestureClick ();
         var secondary_icon = new Gtk.Image ();

--- a/lib/Widgets/SettingsSidebar.vala
+++ b/lib/Widgets/SettingsSidebar.vala
@@ -92,7 +92,7 @@ public class Granite.SettingsSidebar : Gtk.Widget {
                     xalign = 0
                 };
 
-                label.get_style_context ().add_class (Granite.STYLE_CLASS_H4_LABEL);
+                label.add_css_class (Granite.STYLE_CLASS_H4_LABEL);
                 row.set_header (label);
             }
         });

--- a/lib/Widgets/SettingsSidebarRow.vala
+++ b/lib/Widgets/SettingsSidebarRow.vala
@@ -80,7 +80,7 @@ private class Granite.SettingsSidebarRow : Gtk.ListBoxRow {
             vexpand = true,
             xalign = 0
         };
-        title_label.get_style_context ().add_class (Granite.STYLE_CLASS_H3_LABEL);
+        title_label.add_css_class (Granite.STYLE_CLASS_H3_LABEL);
 
         status_icon = new Gtk.Image () {
             halign = Gtk.Align.END,

--- a/lib/Widgets/SwitchModelButton.vala
+++ b/lib/Widgets/SwitchModelButton.vala
@@ -49,10 +49,8 @@ public class Granite.SwitchModelButton : Gtk.ToggleButton {
             wrap = true,
             xalign = 0
         };
-
-        unowned var description_style_context = description_label.get_style_context ();
-        description_style_context.add_class (Granite.STYLE_CLASS_SMALL_LABEL);
-        description_style_context.add_class (Granite.STYLE_CLASS_DIM_LABEL);
+        description_label.add_css_class (Granite.STYLE_CLASS_SMALL_LABEL);
+        description_label.add_css_class (Granite.STYLE_CLASS_DIM_LABEL);
 
         var description_revealer = new Gtk.Revealer () {
             child = description_label

--- a/lib/Widgets/ValidatedEntry.vala
+++ b/lib/Widgets/ValidatedEntry.vala
@@ -62,17 +62,15 @@ public class Granite.ValidatedEntry : Gtk.Entry {
         });
 
         changed.connect_after (() => {
-            unowned Gtk.StyleContext style_context = get_style_context ();
-
             if (text == "") {
                 secondary_icon_name = null;
-                style_context.remove_class (Granite.STYLE_CLASS_ERROR);
+                remove_css_class (Granite.STYLE_CLASS_ERROR);
             } else if (is_valid) {
                 secondary_icon_name = "process-completed-symbolic";
-                style_context.remove_class (Granite.STYLE_CLASS_ERROR);
+                remove_css_class (Granite.STYLE_CLASS_ERROR);
             } else {
                 secondary_icon_name = "process-error-symbolic";
-                style_context.add_class (Granite.STYLE_CLASS_ERROR);
+                add_css_class (Granite.STYLE_CLASS_ERROR);
             }
         });
     }


### PR DESCRIPTION
It is deprecated in Gtk 4.10: https://valadoc.org/gtk4/Gtk.Widget.get_style_context.html

The alternative methods `Gtk.Widget.add_css_class` and `Gtk.Widget.remove_css_class` are available on any version of Gtk 4, so we don't need to change required version of `gtk4` dependency here