### PR TITLE
README: Fix exec name of demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ To install, use `ninja install`
 
     ninja install
 
-To see a demo app of Granite's widgets, run `granite-demo` after installing it:
+To see a demo app of Granite's widgets, run `granite-7-demo` after installing it:
 
-    granite-demo
+    granite-7-demo
 
 
 ## Documentation


### PR DESCRIPTION
As we defined here:

https://github.com/elementary/granite/blob/11b720ebc92b5776a367141e93d8c303e5c8813d/demo/meson.build#L2