### PR TITLE
Styles/Button: add .link style with image

### DIFF
--- a/lib/Styles/Gtk/Button.scss
+++ b/lib/Styles/Gtk/Button.scss
@@ -36,6 +36,28 @@ button {
         }
     }
 
+    &.text-button.link label {
+        background-repeat: no-repeat;
+        background-size: rem(16px);
+
+        &:hover {
+            // FIXME: might be a GTK bug to need `double` for underline to show
+            text-decoration: underline double;
+        }
+
+        &:dir(ltr) {
+            background-image: -gtk-icontheme('adw-external-link-symbolic');
+            padding-right: calc(#{rem(6px)} + #{rem(16px)});
+            background-position: right calc(50% + 0.5px);
+        }
+
+        &:dir(rtl) {
+            background-image: -gtk-icontheme('adw-external-link-symbolic-rtl');
+            padding-left: calc(#{rem(6px)} + #{rem(16px)});
+            background-position: left calc(50% + 0.5px);
+        }
+    }
+
     &.circular {
         // Not 50% because that creates a squished ellipse for non-squares widgets
         border-radius: 9999px;

--- a/lib/Styles/Gtk/Button.scss
+++ b/lib/Styles/Gtk/Button.scss
@@ -42,7 +42,7 @@ button {
 
         &:hover {
             // FIXME: might be a GTK bug to need `double` for underline to show
-            text-decoration: underline double;
+            text-decoration: underline;
         }
 
         &:dir(ltr) {


### PR DESCRIPTION
Based on https://github.com/elementary/stylesheet/pull/923

![Screenshot from 2023-12-06 12 02 26](https://github.com/elementary/granite/assets/7277719/f82dec79-0379-4b8f-b673-e29ff92de54a)

There was a previous comment on the other PR about making this style an opt-in with an additional `.external` style class. Not sure if that's still desired or if this okay to trial for all links. Another option would be an opt-out `.internal` style class since the use case of a link button for navigating inside of an app is probably pretty obscure. I can't think of a case other than System Settings where a link would be used to navigate within the same app