### PR TITLE
Make granite-demo optional

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -65,11 +65,14 @@ i18n = import('i18n')
 
 subdir('lib')
 subdir('data')
-subdir('demo')
 subdir('po')
 
 if get_option('documentation')
     subdir('doc')
+endif
+
+if get_option('demo')
+    subdir('demo')
 endif
 
 # set up post-install script to refresh the GTK icon cache

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,2 +1,3 @@
 option('documentation', type: 'boolean', value: false, description: 'generate documentation with gtk-doc and valadoc')
 option('introspection', type: 'boolean', value: true, description: 'Whether to build introspection files')
+option('demo', type: 'boolean', value: true, description: 'Whether to build granite-demo')


### PR DESCRIPTION
We don't need demo in the Flatpak Platform for example, so disabling demo when building for Flatpak should lessen its size and make build time faster a little