### PR TITLE
HeaderLabel: allow secondary text to use markup

### DIFF
--- a/lib/Widgets/HeaderLabel.vala
+++ b/lib/Widgets/HeaderLabel.vala
@@ -38,6 +38,7 @@ public class Granite.HeaderLabel : Gtk.Widget {
                 }
             } else if (value != null) {
                 secondary_label = new Gtk.Label (value) {
+                    use_markup = true,
                     wrap = true,
                     xalign = 0
                 };


### PR DESCRIPTION
There's some secondary text where we want to have settings links for example in https://github.com/elementary/switchboard-plug-keyboard/pull/480