### PR TITLE
Use Gtk.Image, deprecate style class, demo

### DIFF
--- a/demo/Views/CSSView.vala
+++ b/demo/Views/CSSView.vala
@@ -70,12 +70,12 @@ public class CSSView : Gtk.Box {
         };
         terminal_scroll.add_css_class (Granite.STYLE_CLASS_TERMINAL);
 
-        var back_button_label = new Granite.HeaderLabel ("\"back-button\" style class") ;
+        var back_button_label = new Granite.HeaderLabel ("BackButton") ;
 
-        var back_button = new Gtk.Button.with_label ("Back Button") {
-            halign = Gtk.Align.START
+        var back_button = new Granite.BackButton () {
+            halign = START,
+            label = "Back"
         };
-        back_button.add_css_class (Granite.STYLE_CLASS_BACK_BUTTON);
 
         var scales_header = new Granite.HeaderLabel ("Scales") {
             secondary_text = "\"warmth\" and \"temperature\" style classes"

--- a/lib/Constants.vala
+++ b/lib/Constants.vala
@@ -11,6 +11,7 @@ namespace Granite {
     /**
      * Style class for shaping a {@link Gtk.Button}
      */
+    [Version (deprecated = true, deprecated_since = "7.5.0", replacement = "Granite.BackButton")]
     public const string STYLE_CLASS_BACK_BUTTON = "back-button";
     /**
      * Style class to match the window background

--- a/lib/Widgets/BackButton.vala
+++ b/lib/Widgets/BackButton.vala
@@ -8,12 +8,29 @@
  * {@link Adw.NavigationView}s. It will automatically detect when under a
  * {@link Adw.NavigationView} and label itself with the title of the preceding page.
  */
- public class Granite.BackButton : Gtk.Button {
+[Version (since = "7.5.0")]
+public class Granite.BackButton : Gtk.Button {
+
+    /**
+     * A manually set label when used outside of {@link Adw.NavigationView}
+     */
+    public new string label { get; set; }
+
     construct {
-        add_css_class (Granite.STYLE_CLASS_BACK_BUTTON);
+        var image = new Gtk.Image.from_icon_name ("go-previous-symbolic");
+
+        var label_widget = new Gtk.Label ("");
+
+        var box = new Gtk.Box (HORIZONTAL, 0);
+        box.append (image);
+        box.append (label_widget);
+
+        child = box;
 
         map.connect (on_map);
         clicked.connect (on_click);
+
+        bind_property ("label", label_widget, "label");
     }
 
     private void on_map () {

--- a/lib/Widgets/BackButton.vala
+++ b/lib/Widgets/BackButton.vala
@@ -10,7 +10,6 @@
  */
 [Version (since = "7.5.0")]
 public class Granite.BackButton : Gtk.Button {
-
     /**
      * A manually set label when used outside of {@link Adw.NavigationView}
      */


### PR DESCRIPTION
* Replace the back button in Demo
* Deprecate the back-button style class
* Since we're providing a widget, use an image for the icon. Saves us some questionable CSS
* Allow setting the label manually in case there's some situations where we use this outside of Adw.NavigationView :shrug: 