### PR TITLE
Styles: add semantic colors

### DIFF
--- a/demo/Views/CSSView.vala
+++ b/demo/Views/CSSView.vala
@@ -102,17 +102,31 @@ public class CSSView : Gtk.Box {
 
         var primary_color_button = new Gtk.ColorButton.with_rgba ({ 222, 222, 222, 255 });
 
-        var accent_color_label = new Granite.HeaderLabel ("Accent colored labels and icons");
+        var accent_color_label = new Granite.HeaderLabel ("Colored labels and icons");
 
-        var accent_color_icon = new Gtk.Image.from_icon_name ("emoji-body-symbolic");
-        accent_color_icon.add_css_class (Granite.STYLE_CLASS_ACCENT);
+        var accent_color_box = new Gtk.Box (HORIZONTAL, 6);
+        accent_color_box.append (new Gtk.Image.from_icon_name ("emoji-body-symbolic"));
+        accent_color_box.append (new Gtk.Image.from_icon_name ("face-tired-symbolic"));
+        accent_color_box.append (new Gtk.Label (".accent"));
+        accent_color_box.add_css_class (Granite.STYLE_CLASS_ACCENT);
 
-        var accent_color_string = new Gtk.Label ("Lorem ipsum dolor sit amet");
-        accent_color_string.add_css_class (Granite.STYLE_CLASS_ACCENT);
+        var success_color_box = new Gtk.Box (HORIZONTAL, 6);
+        success_color_box.append (new Gtk.Image.from_icon_name ("process-completed-symbolic"));
+        success_color_box.append (new Gtk.Image.from_icon_name ("face-sick-symbolic"));
+        success_color_box.append (new Gtk.Label (".success"));
+        success_color_box.add_css_class (Granite.STYLE_CLASS_SUCCESS);
 
-        var accent_color_grid = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 6);
-        accent_color_grid.append (accent_color_icon);
-        accent_color_grid.append (accent_color_string);
+        var warning_color_box = new Gtk.Box (HORIZONTAL, 6);
+        warning_color_box.append (new Gtk.Image.from_icon_name ("dialog-warning-symbolic"));
+        warning_color_box.append (new Gtk.Image.from_icon_name ("face-laugh-symbolic"));
+        warning_color_box.append (new Gtk.Label (".warning"));
+        warning_color_box.add_css_class (Granite.STYLE_CLASS_WARNING);
+
+        var error_color_box = new Gtk.Box (HORIZONTAL, 6);
+        error_color_box.append (new Gtk.Image.from_icon_name ("dialog-error-symbolic"));
+        error_color_box.append (new Gtk.Image.from_icon_name ("face-angry-symbolic"));
+        error_color_box.append (new Gtk.Label (".error"));
+        error_color_box.add_css_class (Granite.STYLE_CLASS_ERROR);
 
         var box = new Gtk.Box (Gtk.Orientation.VERTICAL, 12) {
             halign = Gtk.Align.CENTER,
@@ -136,7 +150,10 @@ public class CSSView : Gtk.Box {
         box.append (primary_color_label);
         box.append (primary_color_button);
         box.append (accent_color_label);
-        box.append (accent_color_grid);
+        box.append (accent_color_box);
+        box.append (success_color_box);
+        box.append (warning_color_box);
+        box.append (error_color_box);
 
         var scrolled = new Gtk.ScrolledWindow () {
             child = box

--- a/lib/Constants.vala
+++ b/lib/Constants.vala
@@ -102,6 +102,13 @@ namespace Granite {
      * Style class for a {@link Gtk.Label} to emulate Pango's "<small>" and "size='smaller'"
      */
     public const string STYLE_CLASS_SMALL_LABEL= "small-label";
+
+    /**
+     * Style class for widgets in success state.
+     */
+    [Version (since = "7.5.0")]
+    public const string STYLE_CLASS_SUCCESS = "success";
+
     /**
      * Style class for {@link Gtk.Label} or {@link Gtk.TextView} to emulate the appearance of Terminal. This includes
      * text color, background color, selection highlighting, and selecting the system monospace font.

--- a/lib/Styles/Gtk/Image.scss
+++ b/lib/Styles/Gtk/Image.scss
@@ -1,0 +1,24 @@
+image {
+    color: inherit;
+
+    -gtk-icon-palette:
+        error $error_color,
+        success $success_color,
+        warning $warning-icon-color;
+
+    &:disabled {
+        filter: opacity($disabled-opacity);
+    }
+
+    &:backdrop {
+        -gtk-icon-palette: default;
+    }
+}
+
+.normal-icons {
+    -gtk-icon-size: 16px;
+}
+
+.large-icons {
+    -gtk-icon-size: 32px;
+}

--- a/lib/Styles/Gtk/Index.scss
+++ b/lib/Styles/Gtk/Index.scss
@@ -1,5 +1,6 @@
 @import 'Button.scss';
 @import 'HeaderBar.scss';
+@import 'Image.scss';
 @import 'ShortcutsWindow.scss';
 @import 'Spinner.scss';
 @import 'WindowControls.scss';

--- a/lib/Styles/Index-dark.scss
+++ b/lib/Styles/Index-dark.scss
@@ -36,6 +36,12 @@ $fg-color: white;
 // Inset box shadows
 $highlight_color: rgba(white, 0.2);
 
+// Semantic colors
+$error-color: $STRAWBERRY_300;
+$success-color: $LIME_300;
+$warning-color: $BANANA_100;
+$warning-icon-color: $BANANA_500;
+
 // Common styles
 @import '_label.scss';
 @import '_osd.scss';

--- a/lib/Styles/Index.scss
+++ b/lib/Styles/Index.scss
@@ -36,6 +36,12 @@ $fg-color: $BLACK_500;
 // Inset box shadows
 $highlight_color: white;
 
+// Semantic colors
+$error_color: $STRAWBERRY_500;
+$success_color: $LIME_700;
+$warning_color: $BANANA_900;
+$warning-icon-color: mix($BANANA_500, $BANANA_700, $weight: 50%);
+
 // Common styles
 @import '_label.scss';
 @import '_osd.scss';

--- a/lib/Styles/_common.scss
+++ b/lib/Styles/_common.scss
@@ -80,4 +80,5 @@
     @return $highlight;
 }
 
+$disabled-opacity: 0.5;
 $window_radius: 9px;

--- a/lib/Styles/_label.scss
+++ b/lib/Styles/_label.scss
@@ -29,3 +29,22 @@
 .small-label {
     font-size: 0.85em;
 }
+
+.error {
+    color: $error_color;
+}
+
+.success {
+    color: $success_color;
+}
+
+.warning {
+    color: $warning_color;
+}
+
+.accent:backdrop,
+.error:backdrop,
+.success:backdrop,
+.warning:backdrop {
+    color: inherit;
+}


### PR DESCRIPTION
Skips accent which is handled in https://github.com/elementary/granite/pull/704

* Also add to the demo
* Add missing success constant