### PR TITLE
Styles: add Popover and ModelButton styles

### DIFF
--- a/demo/Views/AccelLabelView.vala
+++ b/demo/Views/AccelLabelView.vala
@@ -22,12 +22,12 @@ public class AccelLabelView : Gtk.Grid {
         logout_button.add_css_class (Granite.STYLE_CLASS_MENUITEM);
 
         var popover_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
-        popover_box.margin_top = popover_box.margin_bottom = 3;
         popover_box.append (lock_button);
         popover_box.append (logout_button);
 
         var popover = new Gtk.Popover () {
-            child = popover_box
+            child = popover_box,
+            has_arrow = false
         };
         popover.add_css_class (Granite.STYLE_CLASS_MENU);
 

--- a/demo/Views/ModeButtonView.vala
+++ b/demo/Views/ModeButtonView.vala
@@ -35,17 +35,16 @@ public class ModeButtonView : Gtk.Box {
             description = "A description of additional affects related to the activation state of this switch"
         };
 
-        var switchbutton_grid = new Gtk.Grid () {
-            margin_top = 3,
-            margin_bottom = 3
-        };
+        var switchbutton_grid = new Gtk.Grid ();
         switchbutton_grid.attach (header_switchmodelbutton, 0, 0);
         switchbutton_grid.attach (switchmodelbutton, 0, 1);
         switchbutton_grid.attach (description_switchmodelbutton, 0, 2);
 
         var switchbutton_popover = new Gtk.Popover () {
-            child = switchbutton_grid
+            child = switchbutton_grid,
+            has_arrow = false
         };
+        switchbutton_popover.add_css_class (Granite.STYLE_CLASS_MENU);
 
         var popover_button = new Gtk.MenuButton () {
             direction = Gtk.ArrowType.UP

--- a/lib/Styles/Gtk/Index.scss
+++ b/lib/Styles/Gtk/Index.scss
@@ -1,5 +1,6 @@
 @import 'Button.scss';
 @import 'HeaderBar.scss';
+@import 'Popover.scss';
 @import 'ShortcutsWindow.scss';
 @import 'Spinner.scss';
 @import 'Tooltip.scss';

--- a/lib/Styles/Gtk/Popover.scss
+++ b/lib/Styles/Gtk/Popover.scss
@@ -10,6 +10,7 @@ popover {
 
     > contents {
         box-shadow:
+            // No highlight because of the arrow
             0 0 0 1px $toplevel-border-color,
             shadow(2);
         border-radius: rem($window_radius);

--- a/lib/Styles/Gtk/Popover.scss
+++ b/lib/Styles/Gtk/Popover.scss
@@ -1,0 +1,49 @@
+popover {
+    > arrow,
+    > contents {
+        background-color: bg_color(1);
+    }
+
+    > arrow {
+        border: 1px solid $toplevel-border-color;
+    }
+
+    > contents {
+        box-shadow:
+            0 0 0 1px $toplevel-border-color,
+            shadow(2);
+        border-radius: rem($window_radius);
+    }
+
+    &.menu > contents {
+        box-shadow:
+            highlight(),
+            0 0 0 1px $toplevel-border-color,
+            shadow(2);
+        padding: rem(6px);
+    }
+}
+
+.menuitem,
+modelbutton {
+    border-radius: rem($window_radius / 2);
+    min-width: rem(150px);
+    transition:
+        background duration("expand") easing(),
+        transform duration("expand") easing("ease-out-back");
+    padding: rem(6px);
+
+    &:hover {
+        background: rgba($fg_color, 0.1);
+    }
+
+    &:active {
+        background: rgba($fg-color, 0.15);
+        // There's an optical illusion because items are wider than
+        // they are tall, so compensate by scaling y a little extra
+        transform: scale(0.98, 0.96);
+        transition:
+            background duration("collapse") easing(),
+            transform duration("collapse") easing();
+    }
+}

--- a/lib/Styles/Gtk/Popover.scss
+++ b/lib/Styles/Gtk/Popover.scss
@@ -28,6 +28,7 @@ popover {
 .menuitem,
 modelbutton {
     border-radius: rem($window_radius / 2);
+    border-spacing: rem(6px);
     min-width: rem(150px);
     transition:
         background duration("expand") easing(),

--- a/lib/Styles/Gtk/ShortcutsWindow.scss
+++ b/lib/Styles/Gtk/ShortcutsWindow.scss
@@ -4,16 +4,14 @@ shortcuts-section {
 
 accelerator,
 .keycap {
-    background: bg-color(4);
+    background: rgba($fg_color, 0.1);
     // Intentionally not in ems since it's used as a stroke
     border-radius: rem($window_radius / 3);
-    box-shadow: 0 1px 0 0 adjust-color(bg-color(4), $lightness: -10%);
-    color: rgba($fg_color, 0.8);
+    box-shadow: inset 0 -1px 0 0 scale-color($toplevel-border-color, $alpha: -50%);
+    color: rgba($fg_color, 0.9);
     font-size: 85%;
-    margin-bottom: 1px;
     min-width: rem(12px);
-    // We trim off 1px on the bottom to account for box-shadow
-    padding: rem(3px) rem(6px) calc(#{rem(3px)} - 1px);
+    padding: rem(3px) rem(6px);
 }
 
 // Characters between keys in Gtk.ShortcutLabel, like + or /


### PR DESCRIPTION
Also fix keycap styles in dark mode

https://github.com/elementary/granite/assets/7277719/ec89228d-2789-4018-ac20-68dc55d81387

Doesn't include switch styles. That was just in inspector for the demo

I'm wondering if modelbutton styles should go in a separate file or not?