### PR TITLE
Styles: add switch

### DIFF
--- a/lib/Styles/Common/_controls.scss
+++ b/lib/Styles/Common/_controls.scss
@@ -11,7 +11,6 @@
         );
     transition: all duration("in-place") easing("default");
 
-
     &:backdrop {
         background-image: none;
     }

--- a/lib/Styles/Common/_controls.scss
+++ b/lib/Styles/Common/_controls.scss
@@ -11,13 +11,14 @@
         );
     transition: all duration("in-place") easing("default");
 
+
     &:backdrop {
-        background-image:
-        linear-gradient(
-            to bottom,
-            scale-color($highlight_color, $alpha: -65%),
-            scale-color($highlight_color, $alpha: -70%)
-        );
+        background-image: none;
+    }
+
+    &:disabled {
+        background-color: bg-color(3);
+        background-image: none;
     }
 }
 

--- a/lib/Styles/Gtk/Index.scss
+++ b/lib/Styles/Gtk/Index.scss
@@ -8,6 +8,7 @@
 @import 'Scrollbar.scss';
 @import 'ShortcutsWindow.scss';
 @import 'Spinner.scss';
+@import 'Switch.scss';
 @import 'Tooltip.scss';
 @import 'WindowControls.scss';
 @import 'Window.scss';

--- a/lib/Styles/Gtk/Switch.scss
+++ b/lib/Styles/Gtk/Switch.scss
@@ -1,0 +1,58 @@
+switch {
+    background-color: scale-color($toplevel-border-color, $alpha: -50%); // FIXME: abstract as trough color?
+    border-radius: 99px;
+
+    &:checked:not(.mode-switch):not(:backdrop) {
+        background: $BLUEBERRY_500; // FIXME: accent color
+    }
+
+    &:disabled {
+        background-color: scale-color($toplevel-border-color, $alpha: -60%); // FIXME: abstract as trough color?
+    }
+
+    image {
+        color: transparent;
+    }
+
+    slider {
+        border-radius: 99px;
+        background-color: bg-color(0);
+        background-image:
+            linear-gradient(
+                to bottom,
+                scale-color($highlight_color, $alpha: -80%),
+                rgba(white, 0)
+            );
+        box-shadow:
+            highlight(),
+            0 0 0 1px $border-color,
+            shadow(2);
+
+        &:backdrop {
+            background-image: none;
+            box-shadow:
+                highlight(),
+                0 0 0 1px $border-color,
+                shadow(1);
+        }
+
+        &:disabled {
+            background-color: bg-color(3);
+            background-image: none;
+            box-shadow:
+                0 0 0 1px $border-color,
+                shadow(1);
+        }
+
+        :focus & {
+            box-shadow:
+                highlight(),
+                0 0 0 1px $BLUEBERRY_500, // FIXME: accent color
+                shadow(2);
+            outline-color: rgba($BLUEBERRY_500, 0.3); // FIXME: accent color
+            // Off-by-one to account for padding-box clip
+            outline-width: rem(3px);
+            outline-style: solid;
+        }
+    }
+}

--- a/lib/Styles/Gtk/Switch.scss
+++ b/lib/Styles/Gtk/Switch.scss
@@ -1,35 +1,25 @@
 switch {
-    background-color: scale-color($toplevel-border-color, $alpha: -50%); // FIXME: abstract as trough color?
+    $trough-color: scale-color($toplevel-border-color, $alpha: -50%);
+
+    background-color: $trough-color;
     border-radius: 99px;
 
-    &:checked:not(.mode-switch):not(:backdrop) {
-        background: $BLUEBERRY_500; // FIXME: accent color
-    }
-
     &:disabled {
-        background-color: scale-color($toplevel-border-color, $alpha: -60%); // FIXME: abstract as trough color?
-    }
-
-    image {
-        color: transparent;
+        background-color: scale-color($trough-color, $alpha: -10%);
     }
 
     slider {
-        border-radius: 99px;
-        background-color: bg-color(0);
-        background-image:
-            linear-gradient(
-                to bottom,
-                scale-color($highlight_color, $alpha: -80%),
-                rgba(white, 0)
-            );
+        @include control;
+
+        border: none;
+
+        border-radius: 50%;
         box-shadow:
             highlight(),
             0 0 0 1px $border-color,
             shadow(2);
 
         &:backdrop {
-            background-image: none;
             box-shadow:
                 highlight(),
                 0 0 0 1px $border-color,
@@ -37,22 +27,9 @@ switch {
         }
 
         &:disabled {
-            background-color: bg-color(3);
-            background-image: none;
             box-shadow:
                 0 0 0 1px $border-color,
                 shadow(1);
-        }
-
-        :focus & {
-            box-shadow:
-                highlight(),
-                0 0 0 1px $BLUEBERRY_500, // FIXME: accent color
-                shadow(2);
-            outline-color: rgba($BLUEBERRY_500, 0.3); // FIXME: accent color
-            // Off-by-one to account for padding-box clip
-            outline-width: rem(3px);
-            outline-style: solid;
         }
     }
 }

--- a/lib/Styles/Index-dark.scss
+++ b/lib/Styles/Index-dark.scss
@@ -26,7 +26,7 @@ $toplevel-border-color: rgba(black, 0.75);
 }
 
 // Outset box shadow or border color on inputs like buttons, entries, checkboxes
-$border-color: rgba(black, 0.4);
+$border-color: rgba(black, 0.3);
 
 // Text, images, and other foreground elements
 $fg-color: white;


### PR DESCRIPTION
![Screenshot from 2025-03-30 19 13 38](https://github.com/user-attachments/assets/33b1902a-e72d-4096-893a-9a4e946cc7d9)

Add basic switch styles. Trying something a little different where the interactive part of the control is raised and the trough is flat. The `:checked` style doesn't include accent color because I'm waiting on #704, but it is intended to use accent color eventually