### PR TITLE
SwitchModelButton: use box layout

### DIFF
--- a/lib/Widgets/SwitchModelButton.vala
+++ b/lib/Widgets/SwitchModelButton.vala
@@ -56,17 +56,16 @@ public class Granite.SwitchModelButton : Gtk.ToggleButton {
             child = description_label
         };
 
+        layout_manager = new Gtk.BoxLayout (HORIZONTAL);
+
+        var box = new Gtk.Box (VERTICAL, 0);
+        box.append (label);
+        box.set_parent (this);
+
         var button_switch = new Gtk.Switch () {
             valign = Gtk.Align.START
         };
-
-        var grid = new Gtk.Grid () {
-            column_spacing = 12
-        };
-        grid.attach (label, 0, 0);
-        grid.attach (button_switch, 1, 0, 1, 2);
-
-        child = grid;
+        button_switch.set_parent (this);
 
         bind_property ("text", label, "label");
         bind_property ("description", description_label, "label");
@@ -82,11 +81,17 @@ public class Granite.SwitchModelButton : Gtk.ToggleButton {
 
         notify["description"].connect (() => {
             if (description == null || description == "") {
-                grid.remove (description_revealer);
+                box.remove (description_revealer);
             } else {
-                grid.attach (description_revealer, 0, 1);
+                box.append (description_revealer);
                 button_switch.bind_property ("active", description_revealer, "reveal-child", GLib.BindingFlags.SYNC_CREATE);
             }
         });
+    }
+
+    ~SwitchModelButton () {
+        while (get_first_child () != null) {
+            get_first_child ().unparent ();
+        }
     }
 }


### PR DESCRIPTION
Gtk.ModelButton is a box layout, not a bin layout. Using a box layout here means we can re-use the same border spacing from Gtk.ModelButton instead of hardcoding it

## BEFORE
![Screenshot from 2024-03-22 09 45 17](https://github.com/elementary/granite/assets/7277719/8a9bdc2d-ca5f-4fdf-a4c0-dfc5ff86252e)

## AFTER
![Screenshot from 2024-03-22 09 41 46](https://github.com/elementary/granite/assets/7277719/cd537479-5df7-4186-8b00-ca2160a47b81)
