### PR TITLE
SwitchModelButton: make switch not focusable

### DIFF
--- a/lib/Widgets/SwitchModelButton.vala
+++ b/lib/Widgets/SwitchModelButton.vala
@@ -63,6 +63,7 @@ public class Granite.SwitchModelButton : Gtk.ToggleButton {
         box.set_parent (this);
 
         var button_switch = new Gtk.Switch () {
+            focusable = false,
             valign = Gtk.Align.START
         };
         button_switch.set_parent (this);


### PR DESCRIPTION
The button itself is already keyboard focusable so we don't need the switch to separately be keyboard focusable. This makes keyboard navigation faster