### PR TITLE
Styles: add List styles

### DIFF
--- a/demo/Views/CSSView.vala
+++ b/demo/Views/CSSView.vala
@@ -43,17 +43,22 @@ public class CSSView : Gtk.Box {
         card.append (header4);
 
         var richlist_label = new Granite.HeaderLabel ("Lists") {
-            secondary_text = "\"rich-list\" and \"frame\" style classes"
+            secondary_text = "\"rich-list\" and \"boxed-list\" style classes"
         };
 
-        var rich_listbox = new Gtk.ListBox () {
-            show_separators = true
+        var separators_modelbutton = new Granite.SwitchModelButton ("Show Separators") {
+            active = true,
+            description = "SwitchModelButton works great here too!"
         };
+
+        var rich_listbox = new Gtk.ListBox ();
         rich_listbox.add_css_class (Granite.STYLE_CLASS_RICH_LIST);
-        rich_listbox.add_css_class (Granite.STYLE_CLASS_FRAME);
+        rich_listbox.add_css_class (Granite.STYLE_CLASS_BOXED_LIST);
         rich_listbox.append (new Gtk.Label ("Row 1"));
         rich_listbox.append (new Gtk.Label ("Row 2"));
-        rich_listbox.append (new Gtk.Label ("Row 3"));
+        rich_listbox.append (separators_modelbutton);
+
+        separators_modelbutton.bind_property ("active", rich_listbox, "show-separators", SYNC_CREATE | DEFAULT);
 
         var terminal_label = new Granite.HeaderLabel ("\"terminal\" style class");
 

--- a/demo/Views/CSSView.vala
+++ b/demo/Views/CSSView.vala
@@ -43,7 +43,7 @@ public class CSSView : Gtk.Box {
         card.append (header4);
 
         var richlist_label = new Granite.HeaderLabel ("Lists") {
-            secondary_text = "\"rich-list\" and \"boxed-list\" style classes"
+            secondary_text = "\"rich-list\" and \"card\" style classes"
         };
 
         var separators_modelbutton = new Granite.SwitchModelButton ("Show Separators") {
@@ -53,7 +53,7 @@ public class CSSView : Gtk.Box {
 
         var rich_listbox = new Gtk.ListBox ();
         rich_listbox.add_css_class (Granite.STYLE_CLASS_RICH_LIST);
-        rich_listbox.add_css_class (Granite.STYLE_CLASS_BOXED_LIST);
+        rich_listbox.add_css_class (Granite.STYLE_CLASS_CARD);
         rich_listbox.append (new Gtk.Label ("Row 1"));
         rich_listbox.append (new Gtk.Label ("Row 2"));
         rich_listbox.append (separators_modelbutton);

--- a/lib/Constants.vala
+++ b/lib/Constants.vala
@@ -23,17 +23,9 @@ namespace Granite {
     public const string STYLE_CLASS_BADGE = "badge";
 
     /**
-     * Style class for syling a {@link Gtk.ListBox} with a frame and rounded corners
-     */
-    [Version (since = "7.5.0")]
-    public const string STYLE_CLASS_BOXED_LIST = "boxed-list";
-
-    /**
      * Style class for adding a small shadow to a container such as for image thumbnails
      *
      * Can be combined with the style class ".collapsed" to further reduce the size of the shadow
-     *
-     * Use STYLE_CLASS_BOXED_LIST with {@link Gtk.ListBox} instead
      */
     public const string STYLE_CLASS_CARD = "card";
     /**

--- a/lib/Constants.vala
+++ b/lib/Constants.vala
@@ -21,10 +21,19 @@ namespace Granite {
      * Style class for numbered badges
      */
     public const string STYLE_CLASS_BADGE = "badge";
+
+    /**
+     * Style class for syling a {@link Gtk.ListBox} with a frame and rounded corners
+     */
+    [Version (since = "7.5.0")]
+    public const string STYLE_CLASS_BOXED_LIST = "boxed-list";
+
     /**
      * Style class for adding a small shadow to a container such as for image thumbnails
      *
      * Can be combined with the style class ".collapsed" to further reduce the size of the shadow
+     *
+     * Use STYLE_CLASS_BOXED_LIST with {@link Gtk.ListBox} instead
      */
     public const string STYLE_CLASS_CARD = "card";
     /**

--- a/lib/Styles/Gtk/Index.scss
+++ b/lib/Styles/Gtk/Index.scss
@@ -3,6 +3,7 @@
 @import 'CheckRadio.scss';
 @import 'HeaderBar.scss';
 @import 'Image.scss';
+@import 'List.scss';
 @import 'Popover.scss';
 @import 'Scrollbar.scss';
 @import 'ShortcutsWindow.scss';

--- a/lib/Styles/Gtk/List.scss
+++ b/lib/Styles/Gtk/List.scss
@@ -14,8 +14,9 @@ list {
         }
     }
 
+    &.card,
     &.boxed-list {
-        @extend .card, .rounded;
+        @extend .rounded;
 
         > row {
             // Rounded top

--- a/lib/Styles/Gtk/List.scss
+++ b/lib/Styles/Gtk/List.scss
@@ -43,8 +43,7 @@ list {
     }
 
 
-    & row.separator,
-    &.separators > row:not(.separator) + row:not(.separator) {
+    &.separators > row + row {
         border-top: 1px solid $border-color;
         box-shadow: inset 0 1px 0 0 scale-color($highlight_color, $alpha: -93%);
     }

--- a/lib/Styles/Gtk/List.scss
+++ b/lib/Styles/Gtk/List.scss
@@ -43,13 +43,10 @@ list {
         }
     }
 
-    &.horizontal row.separator,
-    &.separators.horizontal > row:not(.separator) + row:not(.separator) {
-        border-right: 1px solid $border-color;
-    }
 
-    &:not(.horizontal) row.separator,
-    &.separators:not(.horizontal) > row:not(.separator) + row:not(.separator) {
+    & row.separator,
+    &.separators > row:not(.separator) + row:not(.separator) {
         border-top: 1px solid $border-color;
+        box-shadow: inset 0 1px 0 0 scale-color($highlight_color, $alpha: -93%);
     }
 }

--- a/lib/Styles/Gtk/List.scss
+++ b/lib/Styles/Gtk/List.scss
@@ -2,16 +2,6 @@ list {
     &.rich-list > row {
         padding: rem(6px);
         min-height: rem(32px); //Try to force homogeneous row height
-
-        // more row-height magic
-        > box {
-            button.toggle,
-            > fontbutton,
-            > entry,
-            > spinbutton {
-                margin: rem(3px) 0;
-            }
-        }
     }
 
     &.card,

--- a/lib/Styles/Gtk/List.scss
+++ b/lib/Styles/Gtk/List.scss
@@ -1,0 +1,55 @@
+list {
+    background-color: bg-color(1);
+
+    &.rich-list > row {
+        padding: rem(6px);
+        min-height: rem(32px); //Try to force homogeneous row height
+
+        // more row-height magic
+        > box {
+            button.toggle,
+            > fontbutton,
+            > entry,
+            > spinbutton {
+                margin: rem(3px) 0;
+            }
+        }
+    }
+
+    &.boxed-list {
+        @extend .card, .rounded;
+
+        > row {
+            // Rounded top
+            &:first-child {
+                &, &.expander row.header {
+                    border-top-left-radius: rem($window_radius / 2);
+                    border-top-right-radius: rem($window_radius / 2);
+                }
+            }
+
+            // Rounded bottom
+            &:last-child {
+                &,
+                &.expander:not(:checked),
+                &.expander:not(:checked) row.header,
+                &.expander:checked list.nested,
+                &.expander:checked list.nested > row:last-child {
+                    border-bottom-left-radius: rem($window_radius / 2);
+                    border-bottom-right-radius: rem($window_radius / 2);
+                    border-bottom-width: 0;
+                }
+            }
+        }
+    }
+
+    &.horizontal row.separator,
+    &.separators.horizontal > row:not(.separator) + row:not(.separator) {
+        border-right: 1px solid $border-color;
+    }
+
+    &:not(.horizontal) row.separator,
+    &.separators:not(.horizontal) > row:not(.separator) + row:not(.separator) {
+        border-top: 1px solid $border-color;
+    }
+}

--- a/lib/Styles/Gtk/List.scss
+++ b/lib/Styles/Gtk/List.scss
@@ -1,6 +1,4 @@
 list {
-    background-color: bg-color(1);
-
     &.rich-list > row {
         padding: rem(6px);
         min-height: rem(32px); //Try to force homogeneous row height


### PR DESCRIPTION
* Add `BOXED_LIST` which is used in Gtk.Inspector
* Show SwitchModelButton and show/hide separators feature (this appears to be broken with io.elementary.stylesheet but works with Granite's stylesheet)

todo:
- [x] lists shouldn't have a background color unless they're a boxed or framed list
- [ ] .frame
- [x] Re-evaluate boxed-list vs rich-list vs card. gtk4-widget-factory has rich-list, inspector has .rich-list.boxed-list. adw uses boxed-list. Perhaps rich-list needs to stay to do widget padding/spacing/styles, and we make .card do the same as .boxed-list, but only support .card as a constant?
- [ ] .activatable row styles. Maybe extend .model?