### PR TITLE
Init: Make sure to use documentation comment

### DIFF
--- a/lib/Init.vala
+++ b/lib/Init.vala
@@ -9,7 +9,7 @@ namespace Granite {
     private static Gtk.CssProvider? dark_provider = null;
     private static Gtk.CssProvider? app_provider = null;
 
-    /*
+    /**
      * Initializes Granite.
      * If Granite has already been initialized, the function will return.
      * Makes sure translations and types for Granite are set up properly.

--- a/lib/Widgets/HyperTextView.vala
+++ b/lib/Widgets/HyperTextView.vala
@@ -18,7 +18,7 @@
  */
 
 /**
-* This class enables navigatable URLs in Gtk.TextView
+ * This class enables navigatable URLs in Gtk.TextView
  * @since 6.1.3
  */
 public class Granite.HyperTextView : Gtk.TextView {


### PR DESCRIPTION
Fixes #717

There should be no similarities in the granite source. These are almost the copyright headers:

```
[ryo@lb760m ~/work/tmp/granite (init-doc)]$ git grepn "\/\*" | grep -v "\/\*\*"
grep: warning: stray \ before /
1:demo/GraniteDemo.vala:1:/*
2:demo/Views/AccelLabelView.vala:1:/*
3:demo/Views/ApplicationView.vala:1:/*
4:demo/Views/CSSView.vala:1:/*
5:demo/Views/DateTimePickerView.vala:1:/*
6:demo/Views/DialogsView.vala:1:/*
7:demo/Views/FormView.vala:1:/*
8:demo/Views/HyperTextViewGrid.vala:1:/*
9:demo/Views/ModeButtonView.vala:1:/*
10:demo/Views/OverlayBarView.vala:1:/*
11:demo/Views/OverlayBarView.vala:10:        /* This is necessary to workaround an issue in the stylesheet with buttons packed directly into overlays */
12:demo/Views/SettingsUrisView.vala:1:/*
13:demo/Views/SettingsView/SettingsPage.vala:1:/*
14:demo/Views/SettingsView/SettingsView.vala:1:/*
15:demo/Views/SettingsView/SimpleSettingsPage.vala:1:/*
16:demo/Views/ToastView.vala:1:/*
17:demo/Views/UtilsView.vala:1:/*
18:demo/Views/WelcomeView.vala:1:/*
19:Binary file doc/images/AboutDialog.png matches
20:Binary file doc/images/Welcome.png matches
21:lib/Config.vala.in:1:/*
22:lib/Constants.vala:1:/*
73:lib/DateTime.vala:1:/*
81:lib/Init.vala:1:/*
83:lib/Services/Application.vala:1:/*
89:lib/Services/AsyncMutex.vala:1:/*
90:lib/Services/ContractorProxy.vala:1:/*
106:lib/Services/Portal.vala:1:/*
107:lib/Services/Settings.vala:1:/*
111:lib/Services/System.vala:1:/*
114:lib/Widgets/AbstractSettingsPage.vala:1:/*
123:lib/Widgets/AbstractSimpleSettingsPage.vala:1:/*
131:lib/Widgets/AccelLabel.vala:1:/*
138:lib/Widgets/DatePicker.vala:1:/*
144:lib/Widgets/Dialog.vala:1:/*
148:lib/Widgets/HeaderLabel.vala:1:/*
154:lib/Widgets/HyperTextView.vala:1:/*
156:lib/Widgets/HyperTextView.vala:167:        /*
157:lib/Widgets/MessageDialog.vala:1:/*
175:lib/Widgets/ModeSwitch.vala:1:/*
186:lib/Widgets/OverlayBar.vala:1:/*
192:lib/Widgets/Placeholder.vala:1:/*
199:lib/Widgets/Settings.vala:1:/*-
206:lib/Widgets/SettingsSidebar.vala:1:/*
211:lib/Widgets/SettingsSidebarRow.vala:1:/*
212:lib/Widgets/SwitchModelButton.vala:1:/*
216:lib/Widgets/TimePicker.vala:1:/*
223:lib/Widgets/Toast.vala:1:/*-
232:lib/Widgets/Utils.vala:1:/*
239:lib/Widgets/ValidatedEntry.vala:1:/*
[ryo@lb760m ~/work/tmp/granite (init-doc)]$
```