### PR TITLE
AbstractSimpleSettingsPage: Correct replacement class

### DIFF
--- a/lib/Widgets/AbstractSimpleSettingsPage.vala
+++ b/lib/Widgets/AbstractSimpleSettingsPage.vala
@@ -8,7 +8,7 @@
  * a content area, and an action area.
  */
 
-[Version (deprecated = true, deprecated_since = "7.5.0", replacement = "Switchboard.SimpleSettingsPage")]
+[Version (deprecated = true, deprecated_since = "7.5.0", replacement = "Switchboard.SettingsPage")]
 public abstract class Granite.SimpleSettingsPage : Granite.SettingsPage {
     private Gtk.Label description_label;
     private string _description;


### PR DESCRIPTION
`Switchboard.SimpleSettingsPage` is renamed to `Switchboard.SettingsPage` in https://github.com/elementary/switchboard/pull/283