### PR TITLE
SwitchModelButton: wrap label

### DIFF
--- a/data/granite.metainfo.xml.in
+++ b/data/granite.metainfo.xml.in
@@ -32,6 +32,7 @@
         <p>Improvements:</p>
         <ul>
           <li>Improve screen reader support for SwitchModelButton</li>
+          <li>Wrap long labels for SwitchModelButton</li>
           <li>ValidatedEntry: set AccessibleState for validity</li>
           <li>Updated translations</li>
         </ul>

--- a/demo/Views/ModeButtonView.vala
+++ b/demo/Views/ModeButtonView.vala
@@ -30,7 +30,7 @@ public class ModeButtonView : Gtk.Box {
 
         var switchmodelbutton = new Granite.SwitchModelButton ("Default");
 
-        var description_switchmodelbutton = new Granite.SwitchModelButton ("With Description") {
+        var description_switchmodelbutton = new Granite.SwitchModelButton ("A SwitchModelButton With A Description") {
             active = true,
             description = "A description of additional affects related to the activation state of this switch"
         };

--- a/lib/Widgets/SwitchModelButton.vala
+++ b/lib/Widgets/SwitchModelButton.vala
@@ -37,11 +37,12 @@ public class Granite.SwitchModelButton : Gtk.ToggleButton {
 
     construct {
         var label = new Gtk.Label (text) {
-            ellipsize = Pango.EllipsizeMode.MIDDLE,
-            halign = Gtk.Align.START,
+            halign = START,
             hexpand = true,
-            vexpand = true,
             max_width_chars = 25,
+            vexpand = true,
+            wrap = true,
+            xalign = 0,
             mnemonic_widget = this
         };
 


### PR DESCRIPTION
Ellipsize is not the move here for long labels. It makes it impossible to read the label. Wrap instead