### PR TITLE
Introduce Granite.Bin for subclassing

### DIFF
--- a/lib/Widgets/Bin.vala
+++ b/lib/Widgets/Bin.vala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2024 elementary, Inc. (https://elementary.io)
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+/**
+ * This widget is a simple container that can hold a single child widget.
+ * It is mostly useful for deriving subclasses.
+ *
+ * @since 7.6.0
+ */
+public class Granite.Bin : Gtk.Widget {
+    class construct {
+        set_layout_manager_type (typeof (Gtk.BinLayout));
+    }
+
+    private Gtk.Widget? _child;
+    /**
+     * The child widget of the bin.
+     */
+    public Gtk.Widget? child {
+        get {
+            return _child;
+        }
+
+        set {
+            if (value != null && value.get_parent () != null) {
+                critical ("Tried to set a widget as child that already has a parent.");
+                return;
+            }
+
+            if (_child != null) {
+                _child.unparent ();
+            }
+
+            _child = value;
+
+            if (_child != null) {
+                _child.set_parent (this);
+            }
+        }
+    }
+
+    ~Bin () {
+        if (child != null) {
+            child.unparent ();
+        }
+    }
+}

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -16,6 +16,7 @@ libgranite_sources = files(
     'Widgets/AbstractSettingsPage.vala',
     'Widgets/AbstractSimpleSettingsPage.vala',
     'Widgets/AccelLabel.vala',
+    'Widgets/Bin.vala',
     'Widgets/DatePicker.vala',
     'Widgets/Dialog.vala',
     'Widgets/HeaderLabel.vala',


### PR DESCRIPTION
We are now quite often doing an extension of widget and then setting the layout manager type to bin and doing all the other stuff with manually parenting and unparenting, so instead introduce Granite.Bin which holds only a single widget and is intended for subclassing. It's pretty much the same as [Adw.Bin](https://valadoc.org/libadwaita-1/Adw.Bin.html)