### PR TITLE
Revert "Add space to SwitchModelButton.vala"

### DIFF
--- a/lib/Widgets/SwitchModelButton.vala
+++ b/lib/Widgets/SwitchModelButton.vala
@@ -66,8 +66,7 @@ public class Granite.SwitchModelButton : Gtk.ToggleButton {
 
         var button_switch = new Gtk.Switch () {
             focusable = false,
-            valign = Gtk.Align.START,
-            margin_start = 12
+            valign = Gtk.Align.START
         };
         button_switch.set_parent (this);
 


### PR DESCRIPTION
Reverts elementary/granite#736

this isn’t the correct fix. Spacing should be set in CSS in granite widgets, not hardcoded