### PR TITLE
Add version annotation to Granite.Bin

### DIFF
--- a/lib/Widgets/Bin.vala
+++ b/lib/Widgets/Bin.vala
@@ -9,6 +9,7 @@
  *
  * @since 7.6.0
  */
+[Version (since = "7.6.0")]
 public class Granite.Bin : Gtk.Widget {
     class construct {
         set_layout_manager_type (typeof (Gtk.BinLayout));


### PR DESCRIPTION
So that the .gir file contains the necessary annotations for other language bindings.