### PR TITLE
Add gettext to dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ built for elementary OS.
 You'll need the following dependencies:
 * meson >= 0.57.0
 * gobject-introspection
+* gettext
 * libgee-0.8-dev
 * libgirepository1.0-dev
 * libgtk-4-dev >= 4.4.0


### PR DESCRIPTION
Adds `gettext` to the dependency requirements. I just tried to build Granite on a fresh VM of a fresh ISO download, and meson was complaining about not being able to find msgfmt. This fixes that issue afaik.