### PR TITLE
Propose naming scheme for styling files

### DIFF
--- a/lib/Styles/CONTRIBUTING.md
+++ b/lib/Styles/CONTRIBUTING.md
@@ -1,0 +1,66 @@
+# Contributing
+
+## Padding, Margins, and Border Radii
+
+The base grid unit should be 3px. Sometimes widgets with borders will be "off by one" to align visually.
+
+Border radii should increase as they nest where reasonable. For example button radii is 3px to nest neatly into 6px radii windows, popovers, and OSDs.
+
+## Levels and Dark Style Theory
+
+Widget backgrounds are styled according to "level" or "elevation". Elements gets darker the further away they are in interaction hierarchy. For example, buttons are lightest and containers like sidebars are darkest. Widgets in dark style should follow this same progression from lightest in front to darkest in back, and not simply be inverted.
+
+## A11y
+
+* Colors should pass WCAG AA contrast requirements
+* Where possible, use the `rem()` function so that padding, margins, etc scale when users' adjust text size in system settings
+
+## Focus, Hover, Backdrop, etc
+
+Accent should be used to indicate the current area of focus. When selected, but not focused, use nuetral highlights.
+
+Focused widgets should be highlighted with a ring where possible.
+
+Backdrop states should use nuetral color and reduced depth. Contrast can be reduced in some cases, but be mindful of WCAG requirements even for backdrop elements.
+
+## File Name Conventions
+
+A file should be named after the CSS node it addresses. For instance,
+the file addressing `GtkButton` and its descendants would use the file name
+`Button.scss`. As a `GtkCheckButton` has a different CSS node (`checkbutton`),
+it would be placed into it's own file, named `CheckButton.scss`. If you are
+unsure of what node something uses, it's node can be found under the "Name"
+column of the "CSS Nodes" tab of the "Objects" page in Gtk Inspector.
+
+For nodes that are rarely used outside of the context of a parent node (i.e.
+`check` is rarely used outside of the context of `checkbutton`), they can be
+placed in the parent node file.
+
+CSS style classes, such as `Granite.CssClass.CARD`, should be placed in a
+`_classes.scss` file under the relevant library directory (e.g. Granite, Gtk,
+Adw).
+
+## Testing Changesprimary 
+
+Apps may need to be restarted or the system stylesheet may need to be changed before installed changes take effect.
+
+You can also test changes live with Gtk Inspector. Make sure you have Gtk development libraries installed, then enable the inspector shortcut:
+
+```bash
+    apt install libgtk-3-dev libgtk-4-dev
+    gsettings set org.gtk.Settings.Debug enable-inspector-keybinding true
+    gsettings set org.gtk.gtk4.Settings.Debug enable-inspector-keybinding true
+```
+
+Open an app you wish to test your changes on. Open Gtk Inspector with the keyboard shortcut Shift + Ctrl + D, then navigate to the tab "Custom CSS" in Gtk3 or "CSS in Gtk4. Your changes here will take immediate effect on the focused app. In Gtk4 you may have to toggle the "pause" button in the top left before changes take effect.
+
+## Proposing Changes
+
+Changes should be tested against the following apps to avoid breakage:
+* Gtk Demo
+* Gtk Widget Factory
+* Granite Demo
+
+Avoid hardcoding palette colors where possible. `accent_color` should be used for any hightlights or selection states that should adapt to users' color preferences. Use semantic variables like `warning_color` where possible since these are contrast checked for dark and light styles.
+
+Please provide before and after screenshots of your change where applicable


### PR DESCRIPTION
File name scheme proposal following discussion in #751 . This copies the current contributing document from stylesheet (it already contains relevant guidelines and instructions), and adds a section describing a CSS node-based file naming scheme. This proposes three rules:

1. Each file should primarily address one CSS node, and its relevant CSS style classes. The file should be named after the CSS node it primarily addresses.
2. If a node is rarely used outside of the context of another node (e.g. `check` is rarely used outside the context of a `checkbutton`), it can be included in the "parent" node's file.
3. "Loose" CSS style classes, that aren't restricted to a single node or are otherwise abstracted, should be included in a `_classes.scss` under the relevant directory (e.g. `Granite.CssClass.CARD` would be included in `Styles/Granite/_classes.scss`

This hopefully strikes a balance between making selectors easy to find, while also keeping the overall file count manageable.