### PR TITLE
Styles: Add compile time option for including Gtk stylesheets

### DIFF
--- a/lib/Init.vala
+++ b/lib/Init.vala
@@ -41,6 +41,7 @@ namespace Granite {
 
     private static void register_display (Gdk.Display display) {
         var gtk_settings = Gtk.Settings.get_for_display (display);
+        gtk_settings.gtk_theme_name = "Granite";
         gtk_settings.notify["gtk-application-prefer-dark-theme"].connect (() => {
             set_provider_for_display (display, gtk_settings.gtk_application_prefer_dark_theme);
         });

--- a/lib/Init.vala
+++ b/lib/Init.vala
@@ -70,6 +70,9 @@ namespace Granite {
             if (dark_provider == null) {
                 dark_provider = new Gtk.CssProvider ();
                 dark_provider.load_from_resource ("/io/elementary/granite/Granite-dark.css");
+                #if INCLUDE_GTK
+                    dark_provider.load_from_resource ("/io/elementary/granite/Gtk-dark.css");
+                #endif
             }
 
             Gtk.StyleContext.add_provider_for_display (display, dark_provider, Gtk.STYLE_PROVIDER_PRIORITY_THEME);
@@ -81,6 +84,9 @@ namespace Granite {
             if (base_provider == null) {
                 base_provider = new Gtk.CssProvider ();
                 base_provider.load_from_resource ("/io/elementary/granite/Granite.css");
+                #if INCLUDE_GTK
+                    base_provider.load_from_resource ("/io/elementary/granite/Gtk.css");
+                #endif
             }
 
             Gtk.StyleContext.add_provider_for_display (display, base_provider, Gtk.STYLE_PROVIDER_PRIORITY_THEME);

--- a/lib/Init.vala
+++ b/lib/Init.vala
@@ -99,7 +99,7 @@ namespace Granite {
             }
 
 #if INCLUDE_GTK_STYLESHEETS
-            if (gtk_dark_provider != null) { 
+            if (gtk_dark_provider != null) {
                 Gtk.StyleContext.remove_provider_for_display (display, gtk_dark_provider);
             }
 #endif

--- a/lib/Init.vala
+++ b/lib/Init.vala
@@ -5,8 +5,12 @@
 
 namespace Granite {
     private static bool initialized = false;
-    private static Gtk.CssProvider? base_provider = null;
-    private static Gtk.CssProvider? dark_provider = null;
+    private static Gtk.CssProvider? granite_base_provider = null;
+    private static Gtk.CssProvider? granite_dark_provider = null;
+#if INCLUDE_GTK_STYLESHEETS
+    private static Gtk.CssProvider? gtk_base_provider = null;
+    private static Gtk.CssProvider? gtk_dark_provider = null;
+#endif
     private static Gtk.CssProvider? app_provider = null;
 
     /**
@@ -63,33 +67,59 @@ namespace Granite {
         }
 
         if (prefer_dark_style) {
-            if (base_provider != null) {
-                Gtk.StyleContext.remove_provider_for_display (display, base_provider);
+            if (granite_base_provider != null) {
+                Gtk.StyleContext.remove_provider_for_display (display, granite_base_provider);
             }
 
-            if (dark_provider == null) {
-                dark_provider = new Gtk.CssProvider ();
-                dark_provider.load_from_resource ("/io/elementary/granite/Granite-dark.css");
-                #if INCLUDE_GTK
-                    dark_provider.load_from_resource ("/io/elementary/granite/Gtk-dark.css");
-                #endif
+#if INCLUDE_GTK_STYLESHEETS
+            if (gtk_base_provider != null) {
+                Gtk.StyleContext.remove_provider_for_display (display, gtk_base_provider);
+            }
+#endif
+
+            if (granite_dark_provider == null) {
+                granite_dark_provider = new Gtk.CssProvider ();
+                granite_dark_provider.load_from_resource ("/io/elementary/granite/Granite-dark.css");
             }
 
-            Gtk.StyleContext.add_provider_for_display (display, dark_provider, Gtk.STYLE_PROVIDER_PRIORITY_THEME);
+#if INCLUDE_GTK_STYLESHEETS
+            if (gtk_dark_provider == null) {
+                gtk_dark_provider = new Gtk.CssProvider ();
+                gtk_dark_provider.load_from_resource ("/io/elementary/granite/Gtk-dark.css");
+            }
+#endif
+
+            Gtk.StyleContext.add_provider_for_display (display, granite_dark_provider, Gtk.STYLE_PROVIDER_PRIORITY_THEME);
+#if INCLUDE_GTK_STYLESHEETS
+            Gtk.StyleContext.add_provider_for_display (display, gtk_dark_provider, Gtk.STYLE_PROVIDER_PRIORITY_THEME);
+#endif
         } else {
-            if (dark_provider != null) {
-                Gtk.StyleContext.remove_provider_for_display (display, dark_provider);
+            if (granite_dark_provider != null) {
+                Gtk.StyleContext.remove_provider_for_display (display, granite_dark_provider);
             }
 
-            if (base_provider == null) {
-                base_provider = new Gtk.CssProvider ();
-                base_provider.load_from_resource ("/io/elementary/granite/Granite.css");
-                #if INCLUDE_GTK
-                    base_provider.load_from_resource ("/io/elementary/granite/Gtk.css");
-                #endif
+#if INCLUDE_GTK_STYLESHEETS
+            if (gtk_dark_provider != null) { 
+                Gtk.StyleContext.remove_provider_for_display (display, gtk_dark_provider);
+            }
+#endif
+
+            if (granite_base_provider == null) {
+                granite_base_provider = new Gtk.CssProvider ();
+                granite_base_provider.load_from_resource ("/io/elementary/granite/Granite.css");
             }
 
-            Gtk.StyleContext.add_provider_for_display (display, base_provider, Gtk.STYLE_PROVIDER_PRIORITY_THEME);
+#if INCLUDE_GTK_STYLESHEETS
+            if (gtk_base_provider == null) {
+                gtk_base_provider = new Gtk.CssProvider ();
+                gtk_base_provider.load_from_resource ("/io/elementary/granite/Gtk.css");
+            }
+#endif
+
+            Gtk.StyleContext.add_provider_for_display (display, granite_base_provider, Gtk.STYLE_PROVIDER_PRIORITY_THEME);
+#if INCLUDE_GTK_STYLESHEETS
+            Gtk.StyleContext.add_provider_for_display (display, gtk_base_provider, Gtk.STYLE_PROVIDER_PRIORITY_THEME);
+#endif
         }
     }
 

--- a/lib/Init.vala
+++ b/lib/Init.vala
@@ -41,7 +41,9 @@ namespace Granite {
 
     private static void register_display (Gdk.Display display) {
         var gtk_settings = Gtk.Settings.get_for_display (display);
+#if INCLUDE_GTK_STYLESHEETS
         gtk_settings.gtk_theme_name = "Granite";
+#endif
         gtk_settings.notify["gtk-application-prefer-dark-theme"].connect (() => {
             set_provider_for_display (display, gtk_settings.gtk_application_prefer_dark_theme);
         });

--- a/lib/Styles/Granite-dark.scss
+++ b/lib/Styles/Granite-dark.scss
@@ -1,0 +1,6 @@
+$color-scheme: "dark";
+// Common Styles
+@import 'Index-dark.scss';
+
+// Granite widgets
+@import 'Granite/Index.scss';

--- a/lib/Styles/Granite.scss
+++ b/lib/Styles/Granite.scss
@@ -1,0 +1,6 @@
+$color-scheme: "light";
+// Common Styles
+@import 'Index.scss';
+
+// Granite widgets
+@import 'Granite/Index.scss';

--- a/lib/Styles/Gtk-dark.scss
+++ b/lib/Styles/Gtk-dark.scss
@@ -1,0 +1,6 @@
+$color-scheme: "dark";
+// Common Styles
+@import 'Index-dark.scss';
+
+// Gtk widgets
+@import 'Gtk/Index.scss';

--- a/lib/Styles/Gtk.scss
+++ b/lib/Styles/Gtk.scss
@@ -1,0 +1,6 @@
+$color-scheme: "light";
+// Common Styles
+@import 'Index.scss';
+
+// Gtk widgets
+@import 'Gtk/Index.scss';

--- a/lib/Styles/meson.build
+++ b/lib/Styles/meson.build
@@ -2,9 +2,9 @@ sassc = find_program('sassc')
 
 sassc_opts = [ '-a', '-M', '-t', 'compact' ]
 
-stylesheet_deps = custom_target(
-    'Granite.scss',
-    input: 'Index.scss',
+gtk_stylesheet_deps = custom_target(
+    'Gtk.scss',
+    input: 'Gtk.scss',
     output: 'gtk.css',
     command: [
         sassc,
@@ -16,10 +16,38 @@ stylesheet_deps = custom_target(
     install_dir: get_option('datadir') / 'themes' / 'Granite' / 'gtk-4.0'
 )
 
-stylesheet_dark_deps = custom_target(
-    'Granite-dark.scss',
-    input: 'Index-dark.scss',
+gtk_stylesheet_dark_deps = custom_target(
+    'Gtk-dark.scss',
+    input: 'Gtk-dark.scss',
     output: 'gtk-dark.css',
+    command: [
+        sassc,
+        sassc_opts,
+        '@INPUT@',
+        '@OUTPUT@',
+    ],
+    install: true,
+    install_dir: get_option('datadir') / 'themes' / 'Granite' / 'gtk-4.0'
+)
+
+granite_stylesheet_deps = custom_target(
+    'Granite.scss',
+    input: 'Granite.scss',
+    output: 'granite.css',
+    command: [
+        sassc,
+        sassc_opts,
+        '@INPUT@',
+        '@OUTPUT@',
+    ],
+    install: true,
+    install_dir: get_option('datadir') / 'themes' / 'Granite' / 'gtk-4.0'
+)
+
+granite_stylesheet_dark_deps = custom_target(
+    'Granite-dark.scss',
+    input: 'Granite-dark.scss',
+    output: 'granite-dark.css',
     command: [
         sassc,
         sassc_opts,
@@ -38,7 +66,9 @@ stylesheet_resource = gnome.compile_resources(
         meson.current_source_dir(),
     ],
     dependencies: [
-        stylesheet_deps,
-        stylesheet_dark_deps
+        gtk_stylesheet_deps,
+        gtk_stylesheet_dark_deps,
+        granite_stylesheet_deps,
+        granite_stylesheet_dark_deps
     ]
 )

--- a/lib/Styles/meson.build
+++ b/lib/Styles/meson.build
@@ -12,7 +12,7 @@ gtk_stylesheet_deps = custom_target(
         '@INPUT@',
         '@OUTPUT@',
     ],
-    install: true,
+    install: false,
     install_dir: get_option('datadir') / 'themes' / 'Granite' / 'gtk-4.0'
 )
 
@@ -26,7 +26,7 @@ gtk_stylesheet_dark_deps = custom_target(
         '@INPUT@',
         '@OUTPUT@',
     ],
-    install: true,
+    install: false,
     install_dir: get_option('datadir') / 'themes' / 'Granite' / 'gtk-4.0'
 )
 
@@ -40,7 +40,7 @@ granite_stylesheet_deps = custom_target(
         '@INPUT@',
         '@OUTPUT@',
     ],
-    install: true,
+    install: false,
     install_dir: get_option('datadir') / 'themes' / 'Granite' / 'gtk-4.0'
 )
 
@@ -54,7 +54,7 @@ granite_stylesheet_dark_deps = custom_target(
         '@INPUT@',
         '@OUTPUT@',
     ],
-    install: true,
+    install: false,
     install_dir: get_option('datadir') / 'themes' / 'Granite' / 'gtk-4.0'
 )
 

--- a/lib/Styles/meson.build
+++ b/lib/Styles/meson.build
@@ -12,7 +12,7 @@ gtk_stylesheet_deps = custom_target(
         '@INPUT@',
         '@OUTPUT@',
     ],
-    install: false,
+    install: true,
     install_dir: get_option('datadir') / 'themes' / 'Granite' / 'gtk-4.0'
 )
 
@@ -26,7 +26,7 @@ gtk_stylesheet_dark_deps = custom_target(
         '@INPUT@',
         '@OUTPUT@',
     ],
-    install: false,
+    install: true,
     install_dir: get_option('datadir') / 'themes' / 'Granite' / 'gtk-4.0'
 )
 

--- a/lib/Styles/styles.gresource.xml
+++ b/lib/Styles/styles.gresource.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gresources>
   <gresource prefix="/io/elementary/granite">
-    <file alias="Granite-dark.css" compressed="true">gtk-dark.css</file>
-    <file alias="Granite.css" compressed="true">gtk.css</file>
+    <file alias="Granite-dark.css" compressed="true">granite-dark.css</file>
+    <file alias="Granite.css" compressed="true">granite.css</file>
+    <file alias="Gtk-dark.css" compressed="true">gtk-dark.css</file>
+    <file alias="Gtk.css" compressed="true">gtk.css</file>
   </gresource>
 </gresources>

--- a/meson.build
+++ b/meson.build
@@ -43,10 +43,10 @@ add_project_arguments(
     language: ['vala']
 )
 
-if get_option('gtk')
+if get_option('gtk-stylesheets')
     add_project_arguments(
         '-D',
-        'INCLUDE_GTK',
+        'INCLUDE_GTK_STYLESHEETS',
         language: ['vala']
     )
 endif

--- a/meson.build
+++ b/meson.build
@@ -43,6 +43,14 @@ add_project_arguments(
     language: ['vala']
 )
 
+if get_option('gtk')
+    add_project_arguments(
+        '-D',
+        'INCLUDE_GTK',
+        language: ['vala']
+    )
+endif
+
 libgranite_deps = [
     dependency('gee-0.8'),
     dependency('gio-2.0', version: '>=' + glib_min_version),

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,4 +1,4 @@
 option('documentation', type: 'boolean', value: false, description: 'generate documentation with gtk-doc and valadoc')
 option('introspection', type: 'boolean', value: true, description: 'Whether to build introspection files')
 option('demo', type: 'boolean', value: true, description: 'Whether to build granite-demo')
-option('gtk', type: 'boolean', value: false, description: 'Whether to include stylesheets for Gtk widgets when initializing stylesheets')
+option('gtk-stylesheets', type: 'boolean', value: false, description: 'Whether to include stylesheets for Gtk widgets when initializing stylesheets')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,4 @@
 option('documentation', type: 'boolean', value: false, description: 'generate documentation with gtk-doc and valadoc')
 option('introspection', type: 'boolean', value: true, description: 'Whether to build introspection files')
 option('demo', type: 'boolean', value: true, description: 'Whether to build granite-demo')
+option('gtk', type: 'boolean', value: false, description: 'Whether to include stylesheets for Gtk widgets when initializing stylesheets')


### PR DESCRIPTION
- Splits Gtk and Granite stylesheets into different top level files
- Adds option to `meson_options` to enable loading the Gtk stylesheet at compile time
- I've probably unintentionally broken an API, but I don't know in what way. It seems to work fine with `granite-7-demo`