### PR TITLE
Styles: Move expander code from stylesheet

### DIFF
--- a/lib/Styles/Gtk/Expander.scss
+++ b/lib/Styles/Gtk/Expander.scss
@@ -1,0 +1,18 @@
+expander {
+    min-height: 16px;
+    min-width: 16px;
+    transition: all duration("in-place") easing();
+    -gtk-icon-source: -gtk-icontheme("pan-end-symbolic");
+
+    &:dir(rtl) {
+        -gtk-icon-source: -gtk-icontheme("pan-end-symbolic-rtl");
+    }
+
+    &:checked {
+        -gtk-icon-transform: rotate(90deg);
+
+        &:dir(rtl) {
+            -gtk-icon-transform: rotate(-90deg);
+        }
+    }
+}

--- a/lib/Styles/Gtk/Expander.scss
+++ b/lib/Styles/Gtk/Expander.scss
@@ -1,6 +1,6 @@
 expander {
-    min-height: 16px;
-    min-width: 16px;
+    min-height: rem(16px);
+    min-width: rem(16px);
     transition: all duration("in-place") easing();
     -gtk-icon-source: -gtk-icontheme("pan-end-symbolic");
 

--- a/lib/Styles/Gtk/Index.scss
+++ b/lib/Styles/Gtk/Index.scss
@@ -1,4 +1,5 @@
 @import 'Button.scss';
+@import 'Expander.scss';
 @import 'HeaderBar.scss';
 @import 'Image.scss';
 @import 'Popover.scss';


### PR DESCRIPTION
A small, simple, easy win (for reading Inspector in particular).

![image](https://github.com/user-attachments/assets/983613bf-4311-48cf-b9ee-8609923841cd)