### PR TITLE
Styles: Propose mixin directory structure

### DIFF
--- a/lib/Styles/CONTRIBUTING.md
+++ b/lib/Styles/CONTRIBUTING.md
@@ -40,6 +40,37 @@ CSS style classes, such as `Granite.CssClass.CARD`, should be placed in a
 `_classes.scss` file under the relevant library directory (e.g. Granite, Gtk,
 Adw).
 
+Mixins should be grouped into relevant categories, and placed into a file with
+said category name (e.g. Palette, Typography, Animation)
+
+## Repository Structure
+
+```
+./
+Gtk/
+├─ Index.scss
+├─ _classes.scss
+├─ <1 file per CSS node>
+Granite/
+├─ Index.scss
+├─ _classes.scss
+├─ <1 file per CSS node>
+Adw/
+├─ Index.scss
+├─ _classes.scss
+├─ <1 file per CSS node>
+Mixins/
+├─ Index.scss
+├─ <1 file per Mixin category>
+├─ <e.g. Typography, Animation, Shadows, Borders, Palette, etc.>
+Index.scss
+Index-dark.scss
+Gtk.scss
+Gtk-dark.scss
+Granite.scss
+Granite-dark.scss
+```
+
 ## Testing Changes
 
 Apps may need to be restarted or the system stylesheet may need to be changed before installed changes take effect.


### PR DESCRIPTION
Proposes an expansion to the naming conventions and the repo structure regarding scss mixins:

- Mixins should be grouped into categories and placed in a file named for the category under the `Mixins` directory
- Treats the line between mixins and variables as quite blurry

**For consideration:**

- Currently files containing only variables are included under mixins, but probably shouldn't? Should they be given their own `Variables` directory, or would that make so many files it's unwieldy?