### PR TITLE
Avoid adding empty style classes

### DIFF
--- a/lib/Widgets/Box.vala
+++ b/lib/Widgets/Box.vala
@@ -59,6 +59,10 @@ public class Granite.Box : Gtk.Box {
             }
         }
 
+        if (child_spacing.to_string () == "") {
+            return;
+        }
+
         add_css_class (child_spacing.to_string ());
     }
 }

--- a/lib/Widgets/HeaderLabel.vala
+++ b/lib/Widgets/HeaderLabel.vala
@@ -127,6 +127,10 @@ public class Granite.HeaderLabel : Gtk.Widget {
             }
         }
 
+        if (size.to_string () == "") {
+            return;
+        }
+
         add_css_class (size.to_string ());
     }
 


### PR DESCRIPTION
Fixes a terminal warning. Make sure we don't add a class that has a value of ""