### PR TITLE
Styles/Animate: add spin

### DIFF
--- a/lib/Styles/Common/_animate.scss
+++ b/lib/Styles/Common/_animate.scss
@@ -23,3 +23,9 @@
 
     @return cubic-bezier(0.4, 0, 0.2, 1);
 }
+
+@keyframes spin {
+    to {
+        -gtk-icon-transform: rotate(1turn);
+    }
+}


### PR DESCRIPTION
Add missing spin keyframes to fix Gtk.Spinner animation. Can test in OverlayBar