### PR TITLE
Styles/Controls: merge in background styles

### DIFF
--- a/lib/Styles/Common/_controls.scss
+++ b/lib/Styles/Common/_controls.scss
@@ -1,9 +1,23 @@
 @mixin control {
-    background-color: bg-color(0);
-    background-clip: border-box;
-
     @include border-interactive;
 
+    background-clip: border-box;
+    background-color: bg-color(0);
+    background-image:
+        linear-gradient(
+            to bottom,
+            scale-color($highlight_color, $alpha: -80%),
+            rgba(white, 0)
+        );
     transition: all duration("in-place") easing("default");
+
+    &:backdrop {
+        background-image:
+        linear-gradient(
+            to bottom,
+            scale-color($highlight_color, $alpha: -65%),
+            scale-color($highlight_color, $alpha: -70%)
+        );
+    }
 }
 

--- a/lib/Styles/Common/_lighting.scss
+++ b/lib/Styles/Common/_lighting.scss
@@ -78,22 +78,3 @@
             0 1px 2px rgba(black, 0.24);
     }
 }
-
-// Background for elements with outset style like headerbars, buttons, checkboxes, etc
-%outset-background {
-    background-image:
-        linear-gradient(
-            to bottom,
-            scale-color($highlight_color, $alpha: -80%),
-            rgba(white, 0)
-        );
-
-    &:backdrop {
-        background-image:
-        linear-gradient(
-            to bottom,
-            scale-color($highlight_color, $alpha: -65%),
-            scale-color($highlight_color, $alpha: -70%)
-        );
-    }
-}

--- a/lib/Styles/Gtk/Button.scss
+++ b/lib/Styles/Gtk/Button.scss
@@ -1,7 +1,6 @@
 button {
     
     &.text-button {
-        @extend %outset-background;
         @include control;
         @include border-interactive-roundrect;
     }


### PR DESCRIPTION
Since this is just the background style for controls, merge it into the controls mixin.

Headerbars are pretty much flat by default these days since everything is moving to ToolbarView and split views and the old headerbar style is out of fashion