### PR TITLE
Styles/Classes: reduce card border opacity

### DIFF
--- a/lib/Styles/Granite/_classes.scss
+++ b/lib/Styles/Granite/_classes.scss
@@ -4,7 +4,9 @@
     box-shadow:
         highlight(),
         // Intentionally not in ems since it's used as a stroke
-        0 0 0 1px $border-color,
+        // This stacks with the other shadows,
+        // so reduce it's alpha by the sum of other shadows
+        0 0 0 1px scale-color($border-color, $alpha: -36%),
         shadow(1);
 }
 


### PR DESCRIPTION
Make the borders not so harsh on cards:

## BEFORE
![Screenshot from 2025-03-29 15 29 37](https://github.com/user-attachments/assets/b65d6542-a47f-49ec-af27-b8b1f46b2bd7)

## AFTER
![Screenshot from 2025-03-29 15 31 04](https://github.com/user-attachments/assets/d754e1c6-a725-4910-b9f3-063b7387612a)