### PR TITLE
Add basic Shumate support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Dependencies
         run: |
           apt update
-          apt install -y meson gobject-introspection libgee-0.8-dev libgirepository1.0-dev libgtk-4-dev sassc valac
+          apt install -y meson gobject-introspection libgee-0.8-dev libgirepository1.0-dev libgtk-4-dev libshumate-dev sassc valac
       - name: Build
         env:
           DESTDIR: out

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ You'll need the following dependencies:
 * libgee-0.8-dev
 * libgirepository1.0-dev
 * libgtk-4-dev >= 4.4.0
+* libshumate-dev
 * sassc
 * valac
 

--- a/README.md
+++ b/README.md
@@ -16,9 +16,11 @@ You'll need the following dependencies:
 * libgee-0.8-dev
 * libgirepository1.0-dev
 * libgtk-4-dev >= 4.4.0
-* libshumate-dev
 * sassc
 * valac
+
+To build the Demo you'll additionally need:
+* libshumate-dev
 
 Run `meson build` to configure the build environment:
 

--- a/demo/GraniteDemo.vala
+++ b/demo/GraniteDemo.vala
@@ -24,6 +24,7 @@ public class Granite.Demo : Gtk.Application {
         var form_view = new FormView ();
         var hypertext_view = new HyperTextViewGrid ();
         var controls_view = new ControlsView ();
+        var maps_view = new MapsView ();
         var overlaybar_view = new OverlayBarView ();
         var toast_view = new ToastView ();
         var settings_uris_view = new SettingsUrisView ();
@@ -43,6 +44,7 @@ public class Granite.Demo : Gtk.Application {
         main_stack.add_titled (form_view, "formview", "Forms");
         main_stack.add_titled (hypertext_view, "hypertextview", "HyperTextView");
         main_stack.add_titled (controls_view, "controls", "Controls");
+        main_stack.add_titled (maps_view, "maps", "Maps");
         main_stack.add_titled (overlaybar_view, "overlaybar", "OverlayBar");
         main_stack.add_titled (settings_uris_view, "settings_uris", "Settings URIs");
         main_stack.add_titled (toast_view, "toasts", "Toast");

--- a/demo/Views/MapsView.vala
+++ b/demo/Views/MapsView.vala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2025 elementary, Inc. (https://elementary.io)
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+public class MapsView : DemoPage {
+    construct {
+        var title_label = new Granite.HeaderLabel ("Shumate.SimpleMap") {
+            size = H1
+        };
+
+        var registry = new Shumate.MapSourceRegistry.with_defaults ();
+
+        var simple_map = new Shumate.SimpleMap () {
+            map_source = registry.get_by_id (Shumate.MAP_SOURCE_OSM_MAPNIK),
+            overflow = HIDDEN,
+            vexpand = true
+        };
+        simple_map.add_css_class (Granite.CssClass.CARD);
+
+        var point = new Shumate.Marker () {
+            child = new Gtk.Image.from_icon_name ("emblem-favorite-symbolic"),
+            latitude = 38.580753,
+            longitude = -121.487300
+        };
+
+        var marker_layer = new Shumate.MarkerLayer.full (simple_map.viewport, SINGLE);
+        marker_layer.add_marker (point);
+
+        var map_view = simple_map.viewport;
+        map_view.zoom_level = 15;
+
+        var map = simple_map.map;
+        map.add_layer (marker_layer);
+        map.center_on (38.575764, -121.478851);
+
+        var vbox = new Granite.Box (VERTICAL, DOUBLE) {
+            margin_top = 12,
+            margin_bottom = 12,
+            margin_start = 12,
+            margin_end = 12
+        };
+        vbox.append (title_label);
+        vbox.append (simple_map);
+
+        content = vbox;
+    }
+}

--- a/demo/meson.build
+++ b/demo/meson.build
@@ -13,6 +13,7 @@ executable(
     'Views/DialogsView.vala',
     'Views/FormView.vala',
     'Views/HyperTextViewGrid.vala',
+    'Views/MapsView.vala',
     'Views/OverlayBarView.vala',
     'Views/SettingsUrisView.vala',
     'Views/StyleManagerView.vala',
@@ -20,7 +21,10 @@ executable(
     'Views/UtilsView.vala',
     'Views/WelcomeView.vala',
 
-    dependencies: [libgranite_dep],
+    dependencies: [
+        libgranite_dep,
+        dependency('shumate-1.0')
+    ],
 
     install: true,
 )

--- a/lib/Styles/Gtk/Button.scss
+++ b/lib/Styles/Gtk/Button.scss
@@ -47,4 +47,33 @@ button {
         // Not 50% because that creates a squished ellipse for non-squares widgets
         border-radius: 9999px;
     }
+
+    &.osd {
+        @include control;
+        @include border-interactive-roundrect;
+
+        // This stacks with the other shadows,
+        // so reduce it's alpha by the sum of other shadows
+        $shadow-border-color: scale-color($border-color, $alpha: -50%);
+        @if $color-scheme == "dark" {
+            $shadow-border-color: transparent
+        }
+
+        background-image: none;
+        border: none;
+        box-shadow:
+            highlight(),
+            // Intentionally not in ems since it's used as a stroke
+            0 0 0 1px $shadow-border-color,
+            shadow(2);
+        padding: $button-spacing;
+
+        .linked.vertical &:first-child {
+            box-shadow:
+                highlight("top"),
+                // Intentionally not in ems since it's used as a stroke
+                0 0 0 1px $shadow-border-color,
+                shadow(2);
+        }
+    }
 }

--- a/lib/Styles/Index-dark.scss
+++ b/lib/Styles/Index-dark.scss
@@ -50,3 +50,6 @@ $warning-icon-color: $BANANA_500;
 
 // Granite widgets
 @import 'Granite/Index.scss';
+
+// Maps
+@import 'Shumate/Index.scss';

--- a/lib/Styles/Index.scss
+++ b/lib/Styles/Index.scss
@@ -50,3 +50,6 @@ $warning-icon-color: mix($BANANA_500, $BANANA_700, $weight: 50%);
 
 // Granite widgets
 @import 'Granite/Index.scss';
+
+// Maps
+@import 'Shumate/Index.scss';

--- a/lib/Styles/Shumate/Index.scss
+++ b/lib/Styles/Shumate/Index.scss
@@ -1,0 +1,1 @@
+@import 'MapMarker.scss'

--- a/lib/Styles/Shumate/MapMarker.scss
+++ b/lib/Styles/Shumate/MapMarker.scss
@@ -1,0 +1,25 @@
+map-marker {
+    // This stacks with the other shadows,
+    // so reduce it's alpha by the sum of other shadows
+    $shadow-border-color: scale-color($border-color, $alpha: -50%);
+    @if $color-scheme == "dark" {
+        $shadow-border-color: transparent
+    }
+
+    background-color: bg-color(0);
+    border-radius: 50%;
+    box-shadow:
+        highlight(),
+        // Intentionally not in ems since it's used as a stroke
+        0 0 0 1px $shadow-border-color,
+        shadow(2);
+    padding: $button-spacing / 3;
+
+    image {
+        background: $BLUEBERRY_500;
+        color: white;
+        border-radius: 50%;
+        padding: $button-spacing / 2;
+        -gtk-icon-size: 1rem;
+    }
+}

--- a/lib/Styles/_osd.scss
+++ b/lib/Styles/_osd.scss
@@ -1,4 +1,4 @@
-.osd {
+:not(button).osd {
     background-color: rgba($fg-color, 0.95);
     border-radius: rem($window_radius / 2);
     box-shadow: shadow(1);


### PR DESCRIPTION
Fixes #802 

* Does the least to provide basic styles for Shumate SimpleMap
* Add a style for button.osd
* Make sure we don't add spacing to .osd inside .linked
* Only adds a Shumate dep to the Demo. The library does not depend on Shumate

![Screenshot from 2025-03-31 20 01 44](https://github.com/user-attachments/assets/4fe9101d-266c-4c76-a657-155fe671f1e5)
