### PR TITLE
Control: move shumate to build deps

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,6 +7,7 @@ Build-Depends: debhelper (>= 10.5.1),
                libgee-0.8-dev,
                libgirepository1.0-dev,
                libgtk-4-dev (>= 4.12.0),
+               libshumate-dev,
                meson (>= 0.57.0),
                sassc,
                valac (>= 0.40)
@@ -75,7 +76,7 @@ Description: extension of GTK+ libraries (common files)
 Package: granite-7-demo
 Section: misc
 Architecture: any
-Depends: libgranite7 (= ${binary:Version}), libshumate-dev, ${misc:Depends}, ${shlibs:Depends}
+Depends: libgranite7 (= ${binary:Version}), ${misc:Depends}, ${shlibs:Depends}
 Description: extension of GTK+ libraries (demo binary)
  Granite is an extension of GTK+. Among other things, it provides
  complex widgets and convenience functions designed for use in apps


### PR DESCRIPTION
Shumate was added to demo runtime deps, but we actually need to make it a build time dep

Fixes #822