### PR TITLE
ListItem: add menu_model property

### DIFF
--- a/demo/Views/ListsView.vala
+++ b/demo/Views/ListsView.vala
@@ -34,6 +34,28 @@ public class ListsView : DemoPage {
             secondary_text = "ScrolledWindow with \"has-frame = true\" has a view level background color"
         };
 
+        var reply_menuitem = new GLib.MenuItem ("Reply", null);
+        reply_menuitem.set_attribute_value ("verb-icon", "mail-reply-sender-symbolic");
+
+        var reply_all_menuitem = new GLib.MenuItem ("Reply All", null);
+        reply_all_menuitem.set_attribute_value ("verb-icon", "mail-reply-all-symbolic");
+
+        var forward_menuitem = new GLib.MenuItem ("Forward", null);
+        forward_menuitem.set_attribute_value ("verb-icon", "mail-forward-symbolic");
+
+        var button_menu = new GLib.Menu ();
+        button_menu.append_item (reply_menuitem);
+        button_menu.append_item (reply_all_menuitem);
+        button_menu.append_item (forward_menuitem);
+
+        var button_section = new GLib.MenuItem.section (null, button_menu);
+        button_section.set_attribute_value ("display-hint", "circular-buttons");
+
+        var menu_model = new GLib.Menu ();
+        menu_model.append_item (button_section);
+        menu_model.append ("Move", null);
+        menu_model.append ("Delete", null);
+
         var liststore = new GLib.ListStore (typeof (ListObject));
         liststore.append (new ListObject () {
             text = "Row 1"
@@ -56,7 +78,9 @@ public class ListsView : DemoPage {
         var factory = new Gtk.SignalListItemFactory ();
         factory.setup.connect ((obj) => {
             var list_item = (Gtk.ListItem) obj;
-            list_item.child = new Granite.ListItem ();
+            list_item.child = new Granite.ListItem () {
+                menu_model = menu_model
+            };
         });
 
         factory.bind.connect ((obj) => {


### PR DESCRIPTION
Adds a menu_model property to Granite.ListItem so you can automatically set up a context menu without all the boilerplate

![Screenshot from 2025-04-08 10 32 05](https://github.com/user-attachments/assets/5f1fed32-88ff-4eaa-bd55-57bef033ae89)
