### PR TITLE
Constants: deprecate menu related style classes

### DIFF
--- a/demo/Views/AccelLabelView.vala
+++ b/demo/Views/AccelLabelView.vala
@@ -13,23 +13,31 @@ public class AccelLabelView : DemoPage {
         var popover_label = new Gtk.Label ("In a Popover:");
         popover_label.halign = Gtk.Align.END;
 
-        var lock_button = new Gtk.Button ();
-        lock_button.child = new Granite.AccelLabel ("Lock", "<Super>L");
-        lock_button.add_css_class (Granite.STYLE_CLASS_MENUITEM);
+        var lock_button = new Gtk.Button () {
+            child = new Granite.AccelLabel ("Lock", "<Super>L")
+        };
+        lock_button.add_css_class ("model");
 
-        var logout_button = new Gtk.Button ();
-        logout_button.child = new Granite.AccelLabel ("Log Out…", "<Ctrl><Alt>Delete");
-        logout_button.add_css_class (Granite.STYLE_CLASS_MENUITEM);
+        var logout_button = new Gtk.Button () {
+            child = new Granite.AccelLabel ("Log Out…", "<Ctrl><Alt>Delete")
+        };
+        logout_button.add_css_class ("model");
 
-        var popover_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
-        popover_box.append (lock_button);
-        popover_box.append (logout_button);
+        var lock_item = new GLib.MenuItem (null, null);
+        lock_item.set_attribute_value ("custom", "lock");
 
-        var popover = new Gtk.Popover () {
-            child = popover_box,
+        var logout_item = new GLib.MenuItem (null, null);
+        logout_item.set_attribute_value ("custom", "logout");
+
+        var menu_model = new GLib.Menu ();
+        menu_model.append_item (lock_item);
+        menu_model.append_item (logout_item);
+
+        var popover = new Gtk.PopoverMenu.from_model (menu_model) {
             has_arrow = false
         };
-        popover.add_css_class (Granite.STYLE_CLASS_MENU);
+        popover.add_child (lock_button, "lock");
+        popover.add_child (logout_button, "logout");
 
         var popover_button = new Gtk.MenuButton ();
         popover_button.popover = popover;

--- a/demo/Views/ControlsView.vala
+++ b/demo/Views/ControlsView.vala
@@ -98,16 +98,26 @@ public class ControlsView : DemoPage {
             description = "A description of additional affects related to the activation state of this switch"
         };
 
-        var switchbutton_grid = new Gtk.Grid ();
-        switchbutton_grid.attach (header_switchmodelbutton, 0, 0);
-        switchbutton_grid.attach (switchmodelbutton, 0, 1);
-        switchbutton_grid.attach (description_switchmodelbutton, 0, 2);
+        var header_item = new GLib.MenuItem (null, null);
+        header_item.set_attribute_value ("custom", "header");
 
-        var switchbutton_popover = new Gtk.Popover () {
-            child = switchbutton_grid,
+        var switch_item = new GLib.MenuItem (null, null);
+        switch_item.set_attribute_value ("custom", "switch");
+
+        var description_switch_item = new GLib.MenuItem (null, null);
+        description_switch_item.set_attribute_value ("custom", "description-switch");
+
+        var menu_model = new GLib.Menu ();
+        menu_model.append_item (header_item);
+        menu_model.append_item (switch_item);
+        menu_model.append_item (description_switch_item);
+
+        var switchbutton_popover = new Gtk.PopoverMenu.from_model (menu_model) {
             has_arrow = false
         };
-        switchbutton_popover.add_css_class (Granite.STYLE_CLASS_MENU);
+        switchbutton_popover.add_child (header_switchmodelbutton, "header");
+        switchbutton_popover.add_child (switchmodelbutton, "switch");
+        switchbutton_popover.add_child (description_switchmodelbutton, "description-switch");
 
         var popover_button = new Gtk.MenuButton () {
             direction = Gtk.ArrowType.UP

--- a/lib/Constants.vala
+++ b/lib/Constants.vala
@@ -147,10 +147,12 @@ namespace Granite {
     /**
      * Style class for {@link Gtk.Popover} which is used as a menu.
      */
+    [Version (deprecated = true, deprecated_since = "7.7.0", replacement = "Gtk.PopoverMenu")]
     public const string STYLE_CLASS_MENU = "menu";
     /**
      * Style class for {@link Gtk.Popover} children which are used as menu items.
      */
+    [Version (deprecated = true, deprecated_since = "7.7.0", replacement = "Gtk.PopoverMenu.add_child ()")]
     public const string STYLE_CLASS_MENUITEM = "menuitem";
     /**
      * Style class for dimmed labels.


### PR DESCRIPTION
Gtk.PopoverMenu has a facility for adding custom widgets, so recommend that instead of manually managing style classes for popovers.

I didn't add a constant for "model" because I think it would be better to create a Granite.ModelButton if we want to make it easier to create custom model buttons. But I left that for a future branch as well. I think we need to probably evaluate our popover menus and see what's needed, but to me that's out of scope for just deprecating these two style classes