### PR TITLE
Constants: deprecate scale styles

### DIFF
--- a/demo/Views/CSSView.vala
+++ b/demo/Views/CSSView.vala
@@ -87,27 +87,6 @@ public class CSSView : DemoPage {
         };
         terminal_scroll.add_css_class (Granite.STYLE_CLASS_TERMINAL);
 
-        var scales_header = new Granite.HeaderLabel ("Scales") {
-            secondary_text = "\"warmth\" and \"temperature\" style classes"
-        };
-
-        var warmth_scale = new Gtk.Scale.with_range (Gtk.Orientation.HORIZONTAL, 3500, 6000, 10) {
-            draw_value = false,
-            has_origin = false,
-            hexpand = true,
-            inverted = true
-        };
-        warmth_scale.set_value (6000);
-        warmth_scale.add_css_class (Granite.STYLE_CLASS_WARMTH);
-
-        var temperature_scale = new Gtk.Scale.with_range (Gtk.Orientation.HORIZONTAL, -16.0f, 16.0f, 1.0) {
-            draw_value = false,
-            has_origin = false,
-            hexpand = true
-        };
-        temperature_scale.set_value (0);
-        temperature_scale.add_css_class (Granite.STYLE_CLASS_TEMPERATURE);
-
         var accent_color_label = new Granite.HeaderLabel ("Colored labels and icons");
 
         var accent_color_box = new Gtk.Box (HORIZONTAL, 6);
@@ -150,9 +129,6 @@ public class CSSView : DemoPage {
         box.append (card_box);
         box.append (terminal_label);
         box.append (terminal_scroll);
-        box.append (scales_header);
-        box.append (warmth_scale);
-        box.append (temperature_scale);
         box.append (accent_color_label);
         box.append (accent_color_box);
         box.append (success_color_box);

--- a/lib/Constants.vala
+++ b/lib/Constants.vala
@@ -136,10 +136,12 @@ namespace Granite {
     /**
      * Style class for a warmth scale, a {@link Gtk.Scale} with a "less warm" to "more warm" color gradient
      */
+    [Version (deprecated = true, deprecated_since = "7.7.0")]
     public const string STYLE_CLASS_WARMTH = "warmth";
     /**
      * Style class for a temperature scale, a {@link Gtk.Scale} with a "cold" to "hot" color gradient
      */
+    [Version (deprecated = true, deprecated_since = "7.7.0")]
     public const string STYLE_CLASS_TEMPERATURE = "temperature";
     /**
      * Style class for linked widgets, such as a box containing buttons belonging to the same control.


### PR DESCRIPTION
These constants were never used outside of Granite.

The `warmth` style was added for Nightlight, so it's only used in settings and the indicator. We should just add the styles there. I don't think they're generally useful for apps: https://github.com/search?q=org%3Aelementary+class+%28%22warmth%22%29%3B+language%3AVala&type=code

Same story with the `temperature` style. It was only used in Photos: https://github.com/search?q=org%3Aelementary+add_class+%28%22temperature%22%29+language%3AVala&type=code