### PR TITLE
Constants: deprecate MODE_SWITCH

### DIFF
--- a/lib/Constants.vala
+++ b/lib/Constants.vala
@@ -94,6 +94,7 @@ namespace Granite {
     /**
      * Style class for a {@link Gtk.Switch} used to change between two modes rather than active and inactive states
      */
+    [Version (deprecated = true, deprecated_since = "7.7.0", replacement = "Granite.ModeSwitch")]
     public const string STYLE_CLASS_MODE_SWITCH = "mode-switch";
     /**
      * Style class for "on-screen display" widgets such as {@link Granite.Toast} and {@link Granite.OverlayBar}

--- a/lib/Styles/Gtk/Switch.scss
+++ b/lib/Styles/Gtk/Switch.scss
@@ -1,7 +1,7 @@
 switch {
     @include trough;
 
-    &:checked:not(:backdrop) {
+    &:checked:not(:backdrop):not(.mode-switch) {
         background-color: #{'@accent_color'};
     }
 }

--- a/lib/Widgets/ModeSwitch.vala
+++ b/lib/Widgets/ModeSwitch.vala
@@ -88,7 +88,7 @@ public class Granite.ModeSwitch : Gtk.Box {
 
         var mode_switch = new Gtk.Switch ();
         mode_switch.valign = Gtk.Align.CENTER;
-        mode_switch.add_css_class (Granite.STYLE_CLASS_MODE_SWITCH);
+        mode_switch.add_css_class ("mode-switch");
 
         var secondary_click_controller = new Gtk.GestureClick ();
         var secondary_icon = new Gtk.Image ();


### PR DESCRIPTION
This is internal to Granite and its stylesheet. Developers shouldn't be using this style class, they should use the widget