### PR TITLE
Constants: deprecate KEYCAP

### DIFF
--- a/lib/Constants.vala
+++ b/lib/Constants.vala
@@ -86,6 +86,7 @@ namespace Granite {
     /**
      * Style class for a {@link Gtk.Label} to be displayed as a keyboard key cap
      */
+    [Version (deprecated = true, deprecated_since = "7.7.0", replacement = "Granite.AccelLabel")]
     public const string STYLE_CLASS_KEYCAP = "keycap";
     /**
      * Style class for a {@link Gtk.Image} used to set a context-aware large icon size. By default this is 32px,

--- a/lib/Widgets/AccelLabel.vala
+++ b/lib/Widgets/AccelLabel.vala
@@ -106,7 +106,7 @@ public class Granite.AccelLabel : Gtk.Box {
                     continue;
                 }
                 var accel_label = new Gtk.Label (accel);
-                accel_label.add_css_class (Granite.STYLE_CLASS_KEYCAP);
+                accel_label.add_css_class ("keycap");
 
                 append (accel_label);
             }


### PR DESCRIPTION
This is an internal detail of AccelLabel. App Developers should use that, not this style class