### PR TITLE
Constants: deprecate STYLE_CLASS_FRAME

### DIFF
--- a/lib/Constants.vala
+++ b/lib/Constants.vala
@@ -61,7 +61,7 @@ namespace Granite {
     /**
      * Style class for adding a border to {@link Gtk.ListBox}, {@link Gtk.InfoBar}, and others
      */
-    [Version (deprecated = true, deprecated_since = "7.7.0", replacement = "has_frame = true", since = "7.1.0")]
+    [Version (deprecated = true, deprecated_since = "7.7.0", replacement = "has_frame = true, Granite.CssClass.CARD, or Gtk.Frame", since = "7.1.0")]
     public const string STYLE_CLASS_FRAME = "frame";
     /**
      * Style class for large primary text as seen in {@link Granite.Widgets.Welcome}
@@ -175,7 +175,6 @@ namespace Granite {
     /**
      * Style class for flattened widgets, such as buttons,
      */
-    [Version (deprecated = true, deprecated_since = "7.7.0", replacement = "has_frame = false")]
     public const string STYLE_CLASS_FLAT = "flat";
     /**
      * Style class for message dialogs.

--- a/lib/Constants.vala
+++ b/lib/Constants.vala
@@ -61,7 +61,7 @@ namespace Granite {
     /**
      * Style class for adding a border to {@link Gtk.ListBox}, {@link Gtk.InfoBar}, and others
      */
-    [Version (since = "7.1.0")]
+    [Version (deprecated = true, deprecated_since = "7.7.0", replacement = "has_frame = true", since = "7.1.0")]
     public const string STYLE_CLASS_FRAME = "frame";
     /**
      * Style class for large primary text as seen in {@link Granite.Widgets.Welcome}
@@ -175,6 +175,7 @@ namespace Granite {
     /**
      * Style class for flattened widgets, such as buttons,
      */
+    [Version (deprecated = true, deprecated_since = "7.7.0", replacement = "has_frame = false")]
     public const string STYLE_CLASS_FLAT = "flat";
     /**
      * Style class for message dialogs.


### PR DESCRIPTION
Uses of [FRAME](https://github.com/search?q=org%3Aelementary+STYLE_CLASS_FRAME+language%3AVala&type=code&l=Vala)
* with `Gtk.InfoBar` which is deprecated and needs a replacement widget anyways
* with `Gtk.ScrolledWindow` which has a property [`has_frame`](https://valadoc.org/gtk4/Gtk.ScrolledWindow.has_frame.html)
* with Gtk.ListBox which should either be `CARD` for non-scrolled boxes or on the ScrolledWindow for scrolled boxes
* When there's an ActionBar related to a ScrolledWindow/ListBox. This should probably be like a '.linked' style for ActionBar or a ToolBarview or something. There's also just `Gtk.Frame`. Lot of other possible solutions than adding a frame style to a box