### PR TITLE
Constants: deprecate STYLE_CLASS_FLAT

### DIFF
--- a/lib/Constants.vala
+++ b/lib/Constants.vala
@@ -175,6 +175,7 @@ namespace Granite {
     /**
      * Style class for flattened widgets, such as buttons,
      */
+    [Version (deprecated = true, deprecated_since = "7.7.0", replacement = "has_frame = false")]
     public const string STYLE_CLASS_FLAT = "flat";
     /**
      * Style class for message dialogs.


### PR DESCRIPTION
Uses of [FLAT](https://github.com/search?q=org%3Aelementary+STYLE_CLASS_FLAT+language%3AVala&type=code)
* With Gtk.Button, Gtk.MenuButton should be `has_frame = false`
* With Gtk.HeaderBar. Should be ToolbarView probably. But in the new stylesheet, headerbars are flat by default
* With `Gtk.Frame`. This is nonsensical lol. Don't use a Frame? Use a Bin or something

Todo:
- [ ] With `Granite.STYLE_CLASS_BADGE`. This should probably be a widget I guess? This is used in Mail Sidebar for example
- [ ] With ProgressBar, Levelbar. These are used in Sidebars and ListBoxes. We should probably just make those always flat in those cases so developers don't have to request it manually every time
- [ ] With Gtk.ActionBar. I don't think we ever use a raised style for this widget, so the flat style should probably be the default style. Also, this would be another case where ToolbarView should be used for styles like flat, border, raised etc