### PR TITLE
Styles: Add lighting to progress/scale bars

### DIFF
--- a/lib/Styles/Common/_controls.scss
+++ b/lib/Styles/Common/_controls.scss
@@ -55,8 +55,12 @@
 
     background-color: $trough-color;
     border-radius: 99px;
+    box-shadow: 
+        highlight("bottom"),   
+        inset-shadow();
 
     &:disabled {
         background-color: scale-color($trough-color, $alpha: -10%);
+        box-shadow: inset-shadow("disabled");
     }
 }

--- a/lib/Styles/Common/_controls.scss
+++ b/lib/Styles/Common/_controls.scss
@@ -1,14 +1,8 @@
 @mixin control {
     @include border-interactive;
+    @include lighting-protrude;
 
-    background-clip: border-box;
     background-color: bg-color(0);
-    background-image:
-        linear-gradient(
-            to bottom,
-            scale-color($highlight_color, $alpha: -80%),
-            rgba(white, 0)
-        );
     transition: all duration("in-place") easing("default");
 
     &:backdrop {
@@ -48,6 +42,16 @@
 
 @mixin control-disabled {
     opacity: $disabled-opacity;
+}
+
+@mixin highlightbar {
+    @include border-interactive;
+    @include lighting-protrude;
+    background-color: #{'@accent_color'};
+
+    &:backdrop {
+        background-color: scale-color($fg-color, $alpha: -50%);
+    }
 }
 
 @mixin trough {

--- a/lib/Styles/Common/_controls.scss
+++ b/lib/Styles/Common/_controls.scss
@@ -1,8 +1,13 @@
 @mixin control {
     @include border-interactive;
-    @include lighting-protrude;
-
     background-color: bg-color(0);
+    background-clip: border-box;
+    background-image:
+        linear-gradient(
+            to bottom,
+            scale-color($highlight_color, $alpha: -80%),
+            rgba(white, 0)
+        );
     transition: all duration("in-place") easing("default");
 
     &:backdrop {
@@ -42,16 +47,6 @@
 
 @mixin control-disabled {
     opacity: $disabled-opacity;
-}
-
-@mixin highlightbar {
-    @include border-interactive;
-    @include lighting-protrude;
-    background-color: #{'@accent_color'};
-
-    &:backdrop {
-        background-color: scale-color($fg-color, $alpha: -50%);
-    }
 }
 
 @mixin trough {

--- a/lib/Styles/Common/_controls.scss
+++ b/lib/Styles/Common/_controls.scss
@@ -1,7 +1,8 @@
 @mixin control {
     @include border-interactive;
-    background-color: bg-color(0);
+
     background-clip: border-box;
+    background-color: bg-color(0);
     background-image:
         linear-gradient(
             to bottom,

--- a/lib/Styles/Common/_controls.scss
+++ b/lib/Styles/Common/_controls.scss
@@ -43,6 +43,7 @@
     &:backdrop,
     &:disabled {
         filter: grayscale(100%);
+        opacity: $disabled-opacity;
     }
 }
 
@@ -55,9 +56,7 @@
 
     background-color: $trough-color;
     border-radius: 99px;
-    box-shadow: 
-        highlight("bottom"),   
-        inset-shadow();
+    box-shadow: inset-shadow();
 
     &:disabled {
         background-color: scale-color($trough-color, $alpha: -10%);

--- a/lib/Styles/Common/_lighting.scss
+++ b/lib/Styles/Common/_lighting.scss
@@ -92,13 +92,3 @@
         inset 0 0 1px 1px rgba(black, 0.05);
 }
 
-@mixin lighting-protrude {
-    background-clip: border-box;
-    background-image:
-        linear-gradient(
-            to bottom,
-            scale-color($highlight_color, $alpha: -80%),
-            rgba(white, 0)
-        );
-}
-

--- a/lib/Styles/Common/_lighting.scss
+++ b/lib/Styles/Common/_lighting.scss
@@ -91,3 +91,14 @@
         inset 0 1px 1px rgba(black, 0.05),
         inset 0 0 1px 1px rgba(black, 0.05);
 }
+
+@mixin lighting-protrude {
+    background-clip: border-box;
+    background-image:
+        linear-gradient(
+            to bottom,
+            scale-color($highlight_color, $alpha: -80%),
+            rgba(white, 0)
+        );
+}
+

--- a/lib/Styles/Common/_lighting.scss
+++ b/lib/Styles/Common/_lighting.scss
@@ -91,4 +91,3 @@
         inset 0 1px 1px rgba(black, 0.05),
         inset 0 0 1px 1px rgba(black, 0.05);
 }
-

--- a/lib/Styles/Gtk/ProgressBar.scss
+++ b/lib/Styles/Gtk/ProgressBar.scss
@@ -2,8 +2,8 @@ progressbar {
     $trough-width: rem(9px);
 
     progress {
-        @include highlightbar;
         @include border-interactive-roundrect;
+        background-color: #{'@accent_color'};
 
         &:backdrop {
             filter: grayscale(100%);
@@ -20,7 +20,7 @@ progressbar {
 
     &.horizontal {
         progress {
-            min-height: $trough-width - rem(2px);
+            min-height: $trough-width;
 
             &:not(.pulse) {
                 animation: progress 1.5s easing() infinite;
@@ -32,10 +32,19 @@ progressbar {
                         rgba(white, 0)
                     );
                 background-repeat: no-repeat;
-                background-size: 100% 100%;
+                background-size: 48px 100%;
+
+                box-shadow: -1px 0px scale-color($highlight_color, $alpha: -93%) inset; 
+                border-right: solid 1px $border-color;
 
                 &.right {
                     animation-direction: reverse;
+
+                    border-right: none;
+                    border-left: solid 1px $border-color;
+
+                    box-shadow: none;
+                    box-shadow: 1px 0px scale-color($highlight_color, $alpha: -93%) inset; 
                 }
 
                 &:backdrop {
@@ -48,7 +57,9 @@ progressbar {
 
     &.vertical {
         progress {
-            min-width: $trough-width - rem(2px);
+            min-width: $trough-width;
+            border-top: $border-color 1px solid;
+            box-shadow: highlight("top");
         }
     }
 

--- a/lib/Styles/Gtk/ProgressBar.scss
+++ b/lib/Styles/Gtk/ProgressBar.scss
@@ -2,7 +2,7 @@ progressbar {
     $trough-width: rem(9px);
 
     progress {
-        background-color: #{'@accent_color'};
+        @include highlightbar;
         @include border-interactive-roundrect;
 
         &:backdrop {
@@ -20,7 +20,7 @@ progressbar {
 
     &.horizontal {
         progress {
-            min-height: $trough-width;
+            min-height: $trough-width - rem(2px);
 
             &:not(.pulse) {
                 animation: progress 1.5s easing() infinite;
@@ -32,7 +32,7 @@ progressbar {
                         rgba(white, 0)
                     );
                 background-repeat: no-repeat;
-                background-size: 48px 100%;
+                background-size: 100% 100%;
 
                 &.right {
                     animation-direction: reverse;
@@ -48,7 +48,7 @@ progressbar {
 
     &.vertical {
         progress {
-            min-width: $trough-width;
+            min-width: $trough-width - rem(2px);
         }
     }
 

--- a/lib/Styles/Gtk/ProgressBar.scss
+++ b/lib/Styles/Gtk/ProgressBar.scss
@@ -7,6 +7,7 @@ progressbar {
 
         &:backdrop {
             filter: grayscale(100%);
+            opacity: $disabled-opacity;
         }
     }
 
@@ -34,17 +35,9 @@ progressbar {
                 background-repeat: no-repeat;
                 background-size: 48px 100%;
 
-                box-shadow: -1px 0px scale-color($highlight_color, $alpha: -93%) inset; 
-                border-right: solid 1px $border-color;
-
                 &.right {
                     animation-direction: reverse;
 
-                    border-right: none;
-                    border-left: solid 1px $border-color;
-
-                    box-shadow: none;
-                    box-shadow: 1px 0px scale-color($highlight_color, $alpha: -93%) inset; 
                 }
 
                 &:backdrop {
@@ -58,8 +51,6 @@ progressbar {
     &.vertical {
         progress {
             min-width: $trough-width;
-            border-top: $border-color 1px solid;
-            box-shadow: highlight("top");
         }
     }
 

--- a/lib/Styles/Gtk/ProgressBar.scss
+++ b/lib/Styles/Gtk/ProgressBar.scss
@@ -2,8 +2,8 @@ progressbar {
     $trough-width: rem(9px);
 
     progress {
-        @include border-interactive-roundrect;
         background-color: #{'@accent_color'};
+        @include border-interactive-roundrect;
 
         &:backdrop {
             filter: grayscale(100%);

--- a/lib/Styles/Gtk/Scale.scss
+++ b/lib/Styles/Gtk/Scale.scss
@@ -5,7 +5,11 @@ scale {
 
     // `has_origin = true`
     highlight {
-        @include highlightbar;
+        background-color: #{'@accent_color'};
+
+        &:backdrop {
+            background-color: scale-color($fg-color, $alpha: -50%);
+        }
     }
 
     slider {

--- a/lib/Styles/Gtk/Scale.scss
+++ b/lib/Styles/Gtk/Scale.scss
@@ -9,6 +9,7 @@ scale {
 
         &:backdrop {
             background-color: scale-color($fg-color, $alpha: -50%);
+            opacity: $disabled-opacity;
         }
     }
 

--- a/lib/Styles/Gtk/Scale.scss
+++ b/lib/Styles/Gtk/Scale.scss
@@ -5,11 +5,7 @@ scale {
 
     // `has_origin = true`
     highlight {
-        background-color: #{'@accent_color'};
-
-        &:backdrop {
-            background-color: scale-color($fg-color, $alpha: -50%);
-        }
+        @include highlightbar;
     }
 
     slider {


### PR DESCRIPTION
Basically just transferring the checked styles, using a little bit of lighting to make the bars stand out more. It may be the wrong path to follow, given there seemed to be some support for keeping the initial styles in the discord.

<details>
<summary>Initial Proposal</summary>
<img src="https://github.com/user-attachments/assets/dfde19ad-56b7-440b-a051-dc82ea9fa473" />
<img src="https://github.com/user-attachments/assets/a91fff51-9136-4878-9c78-97a86c9c90d9" />
<img src="https://github.com/user-attachments/assets/5a8b202a-ece1-41cf-8407-84e9edf76b5b" />
<img src="https://github.com/user-attachments/assets/c4179b45-41b9-434b-8d3e-8ae5d5c95767" />
</details>

![image](https://github.com/user-attachments/assets/9707e3c5-1537-4c9b-b99c-a6be7262a9cf)
![image](https://github.com/user-attachments/assets/3212e843-a934-40e8-bb77-50108dfa693c)



