### PR TITLE
Styles/Controls: make active/checked .text-button flat

### DIFF
--- a/lib/Styles/Common/_controls.scss
+++ b/lib/Styles/Common/_controls.scss
@@ -22,11 +22,11 @@
 }
 
 // used to show a button is being clicked or is in an "active" state
-@mixin control-active-depressed {
+@mixin control-active {
+    background: bg-color(3);
     box-shadow:
         highlight("bottom"),
         inset-shadow("");
-        background-color: bg-color(3);
 
     &:disabled {
         box-shadow:
@@ -36,7 +36,7 @@
 }
 
 // used to show a check or radio button is "active"
-@mixin control-active-checked {
+@mixin control-checked {
     color: $SILVER_100;
     background-color: #{'@accent_color'};
 

--- a/lib/Styles/Gtk/Button.scss
+++ b/lib/Styles/Gtk/Button.scss
@@ -26,12 +26,9 @@ button {
         @include control;
         @include border-interactive-roundrect;
 
-        &:checked, &:active {
-            @include control-active-depressed;
-        }
-
-        &:hover {
-            filter: brightness(105%);
+        &:active,
+        &:checked {
+            @include control-active;
         }
 
         &:active {
@@ -40,6 +37,10 @@ button {
 
         &:disabled {
             @include control-disabled;
+        }
+
+        &:hover {
+            filter: brightness(105%);
         }
     }
 

--- a/lib/Styles/Gtk/CheckButton.scss
+++ b/lib/Styles/Gtk/CheckButton.scss
@@ -13,13 +13,13 @@ checkbutton {
         }
 
         &:active {
-            @include control-active-depressed;
+            @include control-active;
             filter: brightness(95%);
         }
 
         &:checked {
             -gtk-icon-source: -gtk-icontheme("check-checked-symbolic");
-            @include control-active-checked;
+            @include control-checked;
         }
 
         &:indeterminate {


### PR DESCRIPTION
Fixes active/checked text-buttons not being very contrasty in dark style

## BEFORE
![Screenshot from 2025-04-28 21 34 47](https://github.com/user-attachments/assets/196f64b1-c2ea-41d5-995d-38e5110c3bc7)

## AFTER
![Screenshot from 2025-04-28 21 45 44](https://github.com/user-attachments/assets/53ca4106-5cba-402f-8dc5-8f89549119d8)
