### PR TITLE
Styles/Button: remove brighten on hover

### DIFF
--- a/lib/Styles/Gtk/Button.scss
+++ b/lib/Styles/Gtk/Button.scss
@@ -30,10 +30,6 @@ button {
             @include control-active-depressed;
         }
 
-        &:hover {
-            filter: brightness(105%);
-        }
-
         &:active {
             filter: brightness(95%);
         }


### PR DESCRIPTION
I really don't like this brightness effect, especially on toggle buttons. I feel like it looks less checked like it's reverting/rejecting being checked

## BEFORE
https://github.com/user-attachments/assets/4069ea5a-253a-4e31-8485-1941543ed99c

##AFTER

https://github.com/user-attachments/assets/69da6295-75c2-4f18-9457-d9dd6dd08d62

