### PR TITLE
accel_to_string: ⌘ → Super

### DIFF
--- a/lib/Widgets/Utils.vala
+++ b/lib/Widgets/Utils.vala
@@ -26,6 +26,7 @@ public static string accel_to_string (string? accel) {
 
     string[] arr = {};
     if (Gdk.ModifierType.SUPER_MASK in accel_mods) {
+        /// TRANSLATORS: The "Super", "Windows", or "Command" key on the keyboard
         arr += _("Super");
     }
 

--- a/lib/Widgets/Utils.vala
+++ b/lib/Widgets/Utils.vala
@@ -26,7 +26,7 @@ public static string accel_to_string (string? accel) {
 
     string[] arr = {};
     if (Gdk.ModifierType.SUPER_MASK in accel_mods) {
-        arr += "⌘";
+        arr += _("Super");
     }
 
     if (Gdk.ModifierType.SHIFT_MASK in accel_mods) {


### PR DESCRIPTION
The original thought process behind using "⌘" was that:
1. No keyboards have the word "Super"
2. We can't use the Windows logo because of trademark
3. Some keyboards have the "⌘" symbol

But now, we have hardware partners like StarLabs which do print keyboards with the word "Super" on the super key. Plus the screen reader announces "⌘" as "Mac command key" instead of "Super". So it would probably be better at this point to switch to the word "Super"