### PR TITLE
Export variables expected by dock

### DIFF
--- a/lib/Styles/_exported.scss
+++ b/lib/Styles/_exported.scss
@@ -3,6 +3,11 @@
 // these exported GtkCSS variables should be considered public API.
 
 @define-color fg_color #{"" + $fg-color};
+@define-color bg_color #{"" + bg-color(2)};
+
+@define-color base_color #{"" + bg-color(1)};
+@define-color highlight_color #{"" + $highlight_color};
+@define-color borders #{"" + $border-color};
 
 @define-color selected_bg_color #{'alpha(@accent_color, 0.25)'};
 @define-color selected_fg_color #{'shade(@accent_color, 0.5)'};


### PR DESCRIPTION
Added back the variables that dock expects to be exported as gtk variables because I got tired of looking at an invisible dock

![image](https://github.com/user-attachments/assets/ca4930be-d222-40dd-930c-48525ada9bac)
