### PR TITLE
Styling: Add `.destructive` class for `button.text-button`

### DIFF
--- a/lib/Styles/Granite/_classes.scss
+++ b/lib/Styles/Granite/_classes.scss
@@ -48,3 +48,7 @@ paper {
     font-family: monospace;
 }
 
+.destructive {
+    background-color: $STRAWBERRY_300;
+    text-shadow: none;
+}

--- a/lib/Styles/Granite/_classes.scss
+++ b/lib/Styles/Granite/_classes.scss
@@ -48,7 +48,12 @@ paper {
     font-family: monospace;
 }
 
-.destructive {
-    background-color: $STRAWBERRY_300;
+button.text-button.destructive {
+    background-color: $error_color;
+    color: bg-color(0);
     text-shadow: none;
+
+    &:active {
+        background-color: mix($error_color, $BLACK_900, 90%);
+    }
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/8f691361-3258-40e7-be2f-7da5c898239f)

Image excluded for now because I don't believe there is a precedent style.