### PR TITLE
Utils: markup_accel_tooltip: Correctly markup documentation

### DIFF
--- a/lib/Widgets/Utils.vala
+++ b/lib/Widgets/Utils.vala
@@ -127,10 +127,10 @@ public const string TOOLTIP_SECONDARY_TEXT_MARKUP = """<span weight="600" size="
  *
  * Example:
  *
- * Description
+ * Description<<BR>>
  * Shortcut 1, Shortcut 2
  *
- * @param a string array of accelerator labels like {"<Control>a", "<Super>Right"}
+ * @param accels a string array of accelerator labels like {"<Control>a", "<Super>Right"}
  *
  * @param description a standard tooltip text string
  *


### PR DESCRIPTION
Fix [the documentation on Valadoc](https://valadoc.org/granite-7/Granite.markup_accel_tooltip.html) is not shown as expected:

<img width="1040" height="599" alt="image" src="https://github.com/user-attachments/assets/cb082833-2ea1-4952-b018-ebcefe1e0da9" />

- `Returns` says that the returned value has two lines but `Example:` is not because we're missing the `<<BR>>` markup
- The description of `accels` is grayed out because we're missing the name of the parameter
