### PR TITLE
meson: Explicit setup

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
           DESTDIR: out
           PKG_CONFIG_PATH: ${{ github.workspace }}/build/meson-uninstalled
         run: |
-          meson build
+          meson setup build
           ninja -C build
           ninja -C build install
 

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ You'll need the following dependencies:
 To build the Demo you'll additionally need:
 * libshumate-dev
 
-Run `meson build` to configure the build environment:
+Run `meson setup` to configure the build environment:
 
-    meson build --prefix=/usr
+    meson setup build --prefix=/usr
 
 This command creates a `build` directory. For all following commands, change to
 the build directory before running them.


### PR DESCRIPTION
Running `meson build` shows the following warning:

```
WARNING: Running the setup command as `meson [options]` instead of `meson setup [options]` is ambiguous and deprecated.
```

Also I think this could lead newcomers misunderstand that `build` is an subcommand of meson, not a build directory.
