### PR TITLE
demo: Replace deprecated Granite.STYLE_CLASS_FRAME

### DIFF
--- a/demo/Views/HyperTextViewGrid.vala
+++ b/demo/Views/HyperTextViewGrid.vala
@@ -27,9 +27,9 @@ public class HyperTextViewGrid : DemoPage {
         var hypertext_scrolled_window = new Gtk.ScrolledWindow () {
             height_request = 300,
             width_request = 600,
-            child = hypertext_textview
+            child = hypertext_textview,
+            has_frame = true
         };
-        hypertext_scrolled_window.add_css_class (Granite.STYLE_CLASS_FRAME);
 
         var box = new Granite.Box (VERTICAL, NONE) {
             halign = CENTER,

--- a/demo/Views/WelcomeView.vala
+++ b/demo/Views/WelcomeView.vala
@@ -45,7 +45,7 @@ public class WelcomeView : DemoPage {
             margin_start = 12
         };
         listbox.set_placeholder (search_placeholder);
-        listbox.add_css_class (Granite.STYLE_CLASS_FRAME);
+        listbox.add_css_class (Granite.CssClass.CARD);
 
         var search_entry = new Gtk.SearchEntry () {
             margin_top = 12,


### PR DESCRIPTION
As raised in https://github.com/elementary/granite/pull/892#issuecomment-3336093976

## Before
<img width="870" height="598" alt="image" src="https://github.com/user-attachments/assets/966f9121-2ef9-4710-8926-065ca4d56f16" />

<img width="870" height="598" alt="image" src="https://github.com/user-attachments/assets/815162ed-fc84-4243-9b08-3da7d2c929c0" />

## After
<img width="870" height="598" alt="image" src="https://github.com/user-attachments/assets/568c3075-ac88-4740-a85d-9a5708310a57" />

<img width="870" height="598" alt="image" src="https://github.com/user-attachments/assets/9ad15e4b-ad8b-4223-a0cc-980e8805de65" />
