### PR TITLE
Box: Add version annotation to Spacing enum

### DIFF
--- a/lib/Widgets/Box.vala
+++ b/lib/Widgets/Box.vala
@@ -10,6 +10,7 @@
  */
 [Version (since = "7.7.0")]
 public class Granite.Box : Gtk.Box {
+    [Version (since = "7.7.0")]
     public enum Spacing {
         NONE,
         // Spacing between groups of related controls like {@link Gtk.CheckButton}


### PR DESCRIPTION
It seems the Vala compiler doesn't add the version annotation to the .gir, even though it's a child of something with the version annotation, so add it explicitly.