### PR TITLE
Rename RDNN to io.elementary.contractor

### DIFF
--- a/lib/Services/ContractorProxy.vala
+++ b/lib/Services/ContractorProxy.vala
@@ -68,7 +68,7 @@ namespace Granite.Services {
         string icon;
     }
 
-    [DBus (name = "org.elementary.Contractor")]
+    [DBus (name = "io.elementary.Contractor")]
     internal interface ContractorDBusAPI : Object {
         public signal void contracts_changed ();
 
@@ -168,8 +168,8 @@ namespace Granite.Services {
             if (contractor_dbus == null) {
                 try {
                     contractor_dbus = Bus.get_proxy_sync (BusType.SESSION,
-                                                          "org.elementary.Contractor",
-                                                          "/org/elementary/contractor");
+                                                          "io.elementary.Contractor",
+                                                          "/io/elementary/contractor");
                     contractor_dbus.contracts_changed.connect (on_contracts_changed);
                 } catch (IOError e) {
                     throw new ContractorError.SERVICE_NOT_AVAILABLE (e.message);


### PR DESCRIPTION
In discussions elementary/contractor#31 and elementary/contractor#41, @ryonakano pointed out the need to transition from `org.elementary.Contractor` to `io.elementary.Contractor` as part of the RDNN rename for OS 9

This PR updates the occurrences in lib/Services/ContractorProxy.vala to match the changes in the Contractor daemon

Note: This change is part of a cross-repo transition and should be merged in coordination with the Contractor PR