### PR TITLE
Fix radius and add subtle sculpting to `.keycap`

### DIFF
--- a/lib/Styles/Gtk/ShortcutsWindow.scss
+++ b/lib/Styles/Gtk/ShortcutsWindow.scss
@@ -5,13 +5,25 @@ shortcuts-section {
 accelerator,
 .keycap {
     background: rgba($fg_color, 0.1);
+    background-image: 
+        linear-gradient(
+            to top,
+            scale-color($highlight_color, $alpha: -80%), 
+            rgba(white, 0)
+        ),
+        linear-gradient(
+            to right,
+            scale-color($highlight_color, $alpha: -85%),
+            rgba(white, 0),
+            scale-color($highlight_color, $alpha: -85%)
+        );
     // Intentionally not in ems since it's used as a stroke
-    border-radius: rem($window_radius / 3);
+    border-radius: rem($window_radius / 2);
     box-shadow: inset 0 -1px 0 0 scale-color($toplevel-border-color, $alpha: -50%);
     color: rgba($fg_color, 0.9);
     font-size: 85%;
     min-width: rem(12px);
-    padding: rem(3px) rem(6px);
+    padding: rem(2px) rem(6px);
 }
 
 // Characters between keys in Gtk.ShortcutLabel, like + or /

--- a/lib/Styles/Gtk/ShortcutsWindow.scss
+++ b/lib/Styles/Gtk/ShortcutsWindow.scss
@@ -23,7 +23,7 @@ accelerator,
     color: rgba($fg_color, 0.9);
     font-size: 85%;
     min-width: rem(12px);
-    padding: rem(2px) rem(6px);
+    padding: rem(4px) rem(4px);
 }
 
 // Characters between keys in Gtk.ShortcutLabel, like + or /


### PR DESCRIPTION
- Adjust border radius and padding to align with 2px grid
- Add some subtle shading to emulate sculpting because I think its fun

## Before

<img width="128" height="74" alt="image" src="https://github.com/user-attachments/assets/fb031b28-d372-45ce-aef8-1c812bcb0ec0" />

<img width="121" height="55" alt="image" src="https://github.com/user-attachments/assets/ec4f67e0-f253-4974-85d3-fe7df0346f0e" />


## After

<img width="124" height="76" alt="image" src="https://github.com/user-attachments/assets/68c81531-84c2-4458-bf3f-8c51db29731a" />

<img width="124" height="82" alt="image" src="https://github.com/user-attachments/assets/26388c44-5673-4b45-be05-786d9d13bbb1" />
