### PR TITLE
ListItem: Ellipsize instead of wrap

### DIFF
--- a/lib/Widgets/ListItem.vala
+++ b/lib/Widgets/ListItem.vala
@@ -76,13 +76,13 @@ public class Granite.ListItem : Gtk.Widget {
         var label = new Gtk.Label ("") {
             hexpand = true,
             vexpand = true,
-            wrap = true,
+            ellipsize = END,
             xalign = 0,
             mnemonic_widget = this
         };
 
         description_label = new Gtk.Label ("") {
-            wrap = true,
+            ellipsize = END,
             xalign = 0
         };
         description_label.add_css_class (Granite.STYLE_CLASS_SMALL_LABEL);

--- a/lib/Widgets/ListItem.vala
+++ b/lib/Widgets/ListItem.vala
@@ -76,12 +76,12 @@ public class Granite.ListItem : Gtk.Widget {
         var label = new Gtk.Label ("") {
             hexpand = true,
             vexpand = true,
-            /* Use ellipsize instead of wrap to make sure we get a consistent height. This is for one
-               aesthetically better instead of having list items with different heights. But more
-               importantly it provides a big performance improvement since we don't need to layout text
-               when measuring this widget. Also ListViews need a consistent height because they need to
-               guess the size of the scrollable viewport and if height changes drastically between items
-               there will be jumps in the scroll position. */
+            /* Use ellipsize instead of wrap to make sure we get a consistent height.
+             * Gtk.ListView needs a homogeneous item height to estimate the height of the Scrollable's Viewport.
+             * If height changes between ListItems there will be jumps in the scroll position.
+             * Also provides a performance improvement since we don't need to layout text when measuring this.
+             * Also aesthetically better instead of having list items with different heights.
+             */
             ellipsize = END,
             xalign = 0,
             mnemonic_widget = this

--- a/lib/Widgets/ListItem.vala
+++ b/lib/Widgets/ListItem.vala
@@ -76,6 +76,12 @@ public class Granite.ListItem : Gtk.Widget {
         var label = new Gtk.Label ("") {
             hexpand = true,
             vexpand = true,
+            /* Use ellipsize instead of wrap to make sure we get a consistent height. This is for one
+               aesthetically better instead of having list items with different heights. But more
+               importantly it provides a big performance improvement since we don't need to layout text
+               when measuring this widget. Also ListViews need a consistent height because they need to
+               guess the size of the scrollable viewport and if height changes drastically between items
+               there will be jumps in the scroll position. */
             ellipsize = END,
             xalign = 0,
             mnemonic_widget = this


### PR DESCRIPTION
I think in lists you usually want to have items of the same size so use ellipsize instead of wrapping.

This also improves performance (by a lot) because list views need to know the height of items to guess the size of the full list and layouting text is very expensive whereas this way you have a fixed height. This also improves predictability because the listview won't get confused when suddenly an item takes up 10 times the height of others (without this you get a sudden change in the scrollbar position and more weirdeness when you scroll an item with a much bigger height into view).