### PR TITLE
GraniteDemo: Fix app id in order to show up in dock

### DIFF
--- a/demo/GraniteDemo.vala
+++ b/demo/GraniteDemo.vala
@@ -5,7 +5,7 @@
 
 public class Granite.Demo : Gtk.Application {
     construct {
-        application_id = "io.elementary.granite.demo";
+        application_id = "io.elementary.granite-9.demo";
         flags = ApplicationFlags.FLAGS_NONE;
     }
 


### PR DESCRIPTION
For non sandboxed apps the application id must match the desktop file app id. This fixes that and causes the granite 9 demo to show up in the dock. Useful for testing the badge and progressbar.