### PR TITLE
HeaderLabel: add justify property

### DIFF
--- a/lib/Widgets/HeaderLabel.vala
+++ b/lib/Widgets/HeaderLabel.vala
@@ -56,6 +56,12 @@ public class Granite.HeaderLabel : Gtk.Widget {
     [Version (since = "7.8.0")]
     public Pango.EllipsizeMode ellipsize { get; set; default = NONE; }
 
+    /**
+     * The horizontal alignment of the label text, forwarded to the underlying {@link Gtk.Label}.
+     */
+    [Version (since = "9.0.0")]
+    public float xalign { get; set; default = 0; }
+
     private Gtk.Label? secondary_label = null;
     /**
      * Optional secondary label string displayed below the header
@@ -76,12 +82,12 @@ public class Granite.HeaderLabel : Gtk.Widget {
             } else if (value != null) {
                 secondary_label = new Gtk.Label (value) {
                     use_markup = true,
-                    wrap = true,
-                    xalign = 0
+                    wrap = true
                 };
                 secondary_label.add_css_class ("subtitle");
 
                 bind_property ("ellipsize", secondary_label, "ellipsize", SYNC_CREATE);
+                bind_property ("xalign", secondary_label, "xalign", SYNC_CREATE);
 
                 secondary_label.set_parent (this);
             }
@@ -107,8 +113,7 @@ public class Granite.HeaderLabel : Gtk.Widget {
 
     construct {
         var label_widget = new Gtk.Label (label) {
-            wrap = true,
-            xalign = 0
+            wrap = true
         };
         label_widget.add_css_class ("heading");
         label_widget.set_parent (this);
@@ -118,6 +123,7 @@ public class Granite.HeaderLabel : Gtk.Widget {
         bind_property ("label", label_widget, "label");
         bind_property ("mnemonic-widget", label_widget, "mnemonic-widget");
         bind_property ("ellipsize", label_widget, "ellipsize", SYNC_CREATE);
+        bind_property ("xalign", label_widget, "xalign", SYNC_CREATE);
 
         notify["mnemonic-widget"].connect (() => {
             update_accessible_description (secondary_text);

--- a/lib/Widgets/HeaderLabel.vala
+++ b/lib/Widgets/HeaderLabel.vala
@@ -57,8 +57,17 @@ public class Granite.HeaderLabel : Gtk.Widget {
     public Pango.EllipsizeMode ellipsize { get; set; default = NONE; }
 
     /**
-     * How the lines of the label are aligned with respect to each other, forwarded to the
-     * underlying {@link Gtk.Label}. Useful for centering a wrapped, multi-line label.
+     * The horizontal alignment of the label text as a whole within its allocation, forwarded
+     * to the underlying {@link Gtk.Label}.
+     */
+    [Version (since = "9.0.0")]
+    public float xalign { get; set; default = 0; }
+
+    /**
+     * How the lines of a wrapped, multi-line label are aligned with respect to each other,
+     * forwarded to the underlying {@link Gtk.Label}. {@link xalign} positions the label as a
+     * block; this controls the alignment of its wrapped lines relative to one another, e.g. to
+     * fully center a wrapped, multi-line label both properties need to be set together.
      */
     [Version (since = "9.0.0")]
     public Gtk.Justification justify { get; set; default = LEFT; }
@@ -88,6 +97,7 @@ public class Granite.HeaderLabel : Gtk.Widget {
                 secondary_label.add_css_class ("subtitle");
 
                 bind_property ("ellipsize", secondary_label, "ellipsize", SYNC_CREATE);
+                bind_property ("xalign", secondary_label, "xalign", SYNC_CREATE);
                 bind_property ("justify", secondary_label, "justify", SYNC_CREATE);
 
                 secondary_label.set_parent (this);
@@ -124,6 +134,7 @@ public class Granite.HeaderLabel : Gtk.Widget {
         bind_property ("label", label_widget, "label");
         bind_property ("mnemonic-widget", label_widget, "mnemonic-widget");
         bind_property ("ellipsize", label_widget, "ellipsize", SYNC_CREATE);
+        bind_property ("xalign", label_widget, "xalign", SYNC_CREATE);
         bind_property ("justify", label_widget, "justify", SYNC_CREATE);
 
         notify["mnemonic-widget"].connect (() => {

--- a/lib/Widgets/HeaderLabel.vala
+++ b/lib/Widgets/HeaderLabel.vala
@@ -57,10 +57,11 @@ public class Granite.HeaderLabel : Gtk.Widget {
     public Pango.EllipsizeMode ellipsize { get; set; default = NONE; }
 
     /**
-     * The horizontal alignment of the label text, forwarded to the underlying {@link Gtk.Label}.
+     * How the lines of the label are aligned with respect to each other, forwarded to the
+     * underlying {@link Gtk.Label}. Useful for centering a wrapped, multi-line label.
      */
     [Version (since = "9.0.0")]
-    public float xalign { get; set; default = 0; }
+    public Gtk.Justification justify { get; set; default = LEFT; }
 
     private Gtk.Label? secondary_label = null;
     /**
@@ -87,7 +88,7 @@ public class Granite.HeaderLabel : Gtk.Widget {
                 secondary_label.add_css_class ("subtitle");
 
                 bind_property ("ellipsize", secondary_label, "ellipsize", SYNC_CREATE);
-                bind_property ("xalign", secondary_label, "xalign", SYNC_CREATE);
+                bind_property ("justify", secondary_label, "justify", SYNC_CREATE);
 
                 secondary_label.set_parent (this);
             }
@@ -123,7 +124,7 @@ public class Granite.HeaderLabel : Gtk.Widget {
         bind_property ("label", label_widget, "label");
         bind_property ("mnemonic-widget", label_widget, "mnemonic-widget");
         bind_property ("ellipsize", label_widget, "ellipsize", SYNC_CREATE);
-        bind_property ("xalign", label_widget, "xalign", SYNC_CREATE);
+        bind_property ("justify", label_widget, "justify", SYNC_CREATE);
 
         notify["mnemonic-widget"].connect (() => {
             update_accessible_description (secondary_text);


### PR DESCRIPTION
## Description

`Granite.HeaderLabel` hardcoded `xalign = 0` on both its primary and secondary internal `Gtk.Label`s, with no way to change it short of reaching into the widget tree via `get_last_child()`.

## Change

- Added a public `xalign` property (`since = "9.0.0"`, matching the current unreleased `meson.build` version), defaulting to `0` to preserve existing behavior.
- Bound it to both the primary label and the secondary label (when present) via `bind_property (..., SYNC_CREATE)`, following the same pattern already used for `ellipsize`.

Note: I don't have a Vala/GTK4 build environment to compile locally, so I've relied on matching the existing binding pattern exactly — happy to iterate on CI/review feedback.

Fixes #977