### PR TITLE
Add notification enums and flags

### DIFF
--- a/lib/Notification.vala
+++ b/lib/Notification.vala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 elementary, Inc. (https://elementary.io)
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+public namespace NotificationCategory {
+    /**
+     * A received instant message notification
+     */
+     public const string IM_RECEIVED = "im.received";
+}
+
+public enum NotificationCategory {
+    /**
+     * A received instant message notification
+     */
+    IM_RECEIVED,
+
+    public string to_string () {
+        switch (this) {
+            case IM_RECEIVED:
+                return "im.received"
+        }
+    }
+}
+
+
+// // For alarm clock apps
+// ALARM_RINGING = "alarm.ringing";
+// // A audio or video call is incoming
+// CALL_INCOMING = "call.incoming";
+// // A audio or video call is ongoing.
+// CALL_ONGOING = "call.ongoing";
+// // An incoming audio or video call was not answered
+// CALL_UNANSWERED = "call.unanswered";
+// // Used to display an extreme weather warning.
+// WEATHER_WARNING_EXTREME = "weather.warning.extreme";
+// // A nationwide or presidential warnings broadcasted by the cell network
+// CELLBROADCAST_DANGER_PRESIDENTIAL = "cellbroadcast.danger.presidential";
+// // Used to display extreme danger warnings broadcasted by the cell network.
+// CELLBROADCAST_DANGER.EXTREME = "cellbroadcast.danger.extreme";
+// // Used to display severe danger warnings broadcasted by the cell network.
+// CELLBROADCAST_DANGER.SEVERE = "cellbroadcast.danger.severe";
+// // Used to display public safety warnings broadcasted by the cell network.
+// CELLBROADCAST_PUBLIC-SAFETY = "cellbroadcast.public-safety";
+// // Used to display amber alerts broadcasted by the cell network.
+// CELLBROADCAST_AMBER-ALERT = "cellbroadcast.amber-alert";
+// // Used to display tests broadcasted by the cell network.
+// CELLBROADCAST_TEST = "cellbroadcast.test";
+// // Used to indicate that the system is low on battery.
+// OS_BATTERY_LOW = "os.battery.low";
+// // Used by browsers to mark notifications sent by websites
+// BROWSER_WEB_NOTIFICATION = "browser.web-notification"
+

--- a/lib/Notification.vala
+++ b/lib/Notification.vala
@@ -4,6 +4,37 @@
  */
 
 [Version (since = "9.0.0")]
+public enum Granite.NotificationButtonPurpose {
+    /**
+     * Accept the incoming call
+     */
+    CALL_ACCEPT,
+
+    /**
+     * Decline the incoming call
+     */
+    CALL_DECLINE,
+
+    /**
+     * Hang up the ongoing call
+     */
+    CALL_HANG_UP;
+
+    public string to_string () {
+        switch (this) {
+            case CALL_ACCEPT:
+                return "call.accept";
+            case CALL_DECLINE:
+                return "call.accept";
+            case CALL_HANG_UP:
+                return "call.accept";
+            default:
+                return "";
+        }
+    }
+}
+
+[Version (since = "9.0.0")]
 public enum Granite.NotificationCategory {
     /**
      * A received instant message notification
@@ -62,97 +93,20 @@ public enum Granite.NotificationCategory {
     }
 }
 
-[Version (since = "9.0.0")]
-public enum Granite.NotificationPriority {
-    /**
-     * Used for contextual background information or confirmations such as contact birthdays or started background tasks
-     *
-     * Are automatically cleared from Notifications menu after 24 hours
-     */
-    LOW,
-
-    /**
-     * The default priority used for the majority of notications. For example, new messages or completed background tasks
-     */
-    NORMAL,
-
-    /**
-     * For events that require immediate action. For example, accepting phone calls or silencing alarms
-     *
-     * Bubbles do not automatically expire, but are automatically cleared from Notifications menu after 24 hours
-     */
-    TIME_SENSITIVE,
-
-    /**
-     * For events that require immediate attention such as imminent danger to this device, or threats to public safety
-     *
-     * Ignore Do Not Disturb.
-     * Play a louder sound and have an exaggerated visual effect.
-     * Bubbles do not automatically expire, but are automatically cleared from Notifications menu after 24 hours
-     */
-     EMERGENCY;
-
-    public string to_string () {
-        switch (this) {
-            case LOW:
-                return "low";
-            case NORMAL:
-                return "normal";
-            case TIME_SENSITIVE:
-                return "high";
-            case EMERGENCY:
-                return "urgent";
-            default:
-                return "";
-        }
-    }
-}
-
-[Version (since = "9.0.0")]
-public enum Granite.NotificationButtonPurpose {
-    /**
-     * Accept the incoming call
-     */
-    CALL_ACCEPT,
-
-    /**
-     * Decline the incoming call
-     */
-    CALL_DECLINE,
-
-    /**
-     * Hang up the ongoing call
-     */
-    CALL_HANG_UP;
-
-    public string to_string () {
-        switch (this) {
-            case CALL_ACCEPT:
-                return "call.accept";
-            case CALL_DECLINE:
-                return "call.accept";
-            case CALL_HANG_UP:
-                return "call.accept";
-            default:
-                return "";
-        }
-    }
-}
-
 [Flags]
 [Version (since = "9.0.0")]
 public enum Granite.NotificationDisplayFlags {
     /**
      * The notification is displayed only as a bubble and won’t be kept in the Notifications menu.
      *
-     * It’s a programmer error to specify tray at the same time.
+     * It’s a programmer error to specify SILENT at the same time.
      */
     TRANSIENT,
 
     /**
      * No bubble for the notification will be displayed and the notification is placed directly in the Notifications menu
      *
-     * It’s a programmer error to specify transient at the same time
+     * It’s a programmer error to specify TRANSIENT at the same time
      */
     SILENT,
 
@@ -207,5 +161,51 @@ public enum Granite.NotificationDisplayFlags {
         }
 
         return array;
+    }
+}
+
+[Version (since = "9.0.0")]
+public enum Granite.NotificationPriority {
+    /**
+     * Used for contextual background information or confirmations such as contact birthdays or started background tasks
+     *
+     * Are automatically cleared from Notifications menu after 24 hours
+     */
+    LOW,
+
+    /**
+     * The default priority used for the majority of notications. For example, new messages or completed background tasks
+     */
+    NORMAL,
+
+    /**
+     * For events that require immediate action. For example, accepting phone calls or silencing alarms
+     *
+     * Bubbles do not automatically expire, but are automatically cleared from Notifications menu after 24 hours
+     */
+    TIME_SENSITIVE,
+
+    /**
+     * For events that require immediate attention such as imminent danger to this device, or threats to public safety
+     *
+     * Ignore Do Not Disturb.
+     * Play a louder sound and have an exaggerated visual effect.
+     * Bubbles do not automatically expire, but are automatically cleared from Notifications menu after 24 hours
+     */
+     EMERGENCY;
+
+    public string to_string () {
+        switch (this) {
+            case LOW:
+                return "low";
+            case NORMAL:
+                return "normal";
+            case TIME_SENSITIVE:
+                return "high";
+            case EMERGENCY:
+                return "urgent";
+            default:
+                return "";
+        }
     }
 }

--- a/lib/Notification.vala
+++ b/lib/Notification.vala
@@ -3,52 +3,209 @@
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 
-public namespace NotificationCategory {
-    /**
-     * A received instant message notification
-     */
-     public const string IM_RECEIVED = "im.received";
-}
-
-public enum NotificationCategory {
+[Version (since = "9.0.0")]
+public enum Granite.NotificationCategory {
     /**
      * A received instant message notification
      */
     IM_RECEIVED,
 
+    /**
+     * For alarm clock apps
+     */
+    ALARM_RINGING,
+
+    /**
+     * A audio or video call is incoming
+     */
+    CALL_INCOMING,
+
+    /**
+     * A audio or video call is ongoing
+     */
+    CALL_ONGOING,
+
+    /**
+     * An incoming audio or video call was not answered
+     */
+    CALL_UNANSWERED,
+
+    /**
+     * Used to display an extreme weather warning
+     */
+    WEATHER_WARNING_EXTREME,
+
+    /**
+     * Used by browsers to mark notifications sent by websites
+     */
+    BROWSER_WEB_NOTIFICATION;
+
     public string to_string () {
         switch (this) {
             case IM_RECEIVED:
-                return "im.received"
+                return "im.received";
+            case ALARM_RINGING:
+                return "alarm.ringing";
+            case CALL_INCOMING:
+                return "call.incoming";
+            case CALL_ONGOING:
+                return "call.ongoing";
+            case CALL_UNANSWERED:
+                return "call.unanswered";
+            case WEATHER_WARNING_EXTREME:
+                return "weather.warning.extreme";
+            case BROWSER_WEB_NOTIFICATION:
+                return "browser.web-notification";
+            default:
+                return "";
         }
     }
 }
 
+[Version (since = "9.0.0")]
+public enum Granite.NotificationPriority {
+    /**
+     * Used for contextual background information or confirmations such as contact birthdays or started background tasks
+     *
+     * Are automatically cleared from Notifications menu after 24 hours
+     */
+    LOW,
 
-// // For alarm clock apps
-// ALARM_RINGING = "alarm.ringing";
-// // A audio or video call is incoming
-// CALL_INCOMING = "call.incoming";
-// // A audio or video call is ongoing.
-// CALL_ONGOING = "call.ongoing";
-// // An incoming audio or video call was not answered
-// CALL_UNANSWERED = "call.unanswered";
-// // Used to display an extreme weather warning.
-// WEATHER_WARNING_EXTREME = "weather.warning.extreme";
-// // A nationwide or presidential warnings broadcasted by the cell network
-// CELLBROADCAST_DANGER_PRESIDENTIAL = "cellbroadcast.danger.presidential";
-// // Used to display extreme danger warnings broadcasted by the cell network.
-// CELLBROADCAST_DANGER.EXTREME = "cellbroadcast.danger.extreme";
-// // Used to display severe danger warnings broadcasted by the cell network.
-// CELLBROADCAST_DANGER.SEVERE = "cellbroadcast.danger.severe";
-// // Used to display public safety warnings broadcasted by the cell network.
-// CELLBROADCAST_PUBLIC-SAFETY = "cellbroadcast.public-safety";
-// // Used to display amber alerts broadcasted by the cell network.
-// CELLBROADCAST_AMBER-ALERT = "cellbroadcast.amber-alert";
-// // Used to display tests broadcasted by the cell network.
-// CELLBROADCAST_TEST = "cellbroadcast.test";
-// // Used to indicate that the system is low on battery.
-// OS_BATTERY_LOW = "os.battery.low";
-// // Used by browsers to mark notifications sent by websites
-// BROWSER_WEB_NOTIFICATION = "browser.web-notification"
+    /**
+     * The default priority used for the majority of notications. For example, new messages or completed background tasks
+     */
+    NORMAL,
 
+    /**
+     * For events that require immediate action. For example, accepting phone calls or silencing alarms
+     *
+     * Bubbles do not automatically expire, but are automatically cleared from Notifications menu after 24 hours
+     */
+    TIME_SENSITIVE,
+
+    /**
+     * For events that require immediate attention such as imminent danger to this device, or threats to public safety
+     *
+     * Ignore Do Not Disturb.
+     * Play a louder sound and have an exaggerated visual effect.
+     * Bubbles do not automatically expire, but are automatically cleared from Notifications menu after 24 hours
+     */
+     EMERGENCY;
+
+    public string to_string () {
+        switch (this) {
+            case LOW:
+                return "low";
+            case NORMAL:
+                return "normal";
+            case TIME_SENSITIVE:
+                return "high";
+            case EMERGENCY:
+                return "urgent";
+            default:
+                return "";
+        }
+    }
+}
+
+[Version (since = "9.0.0")]
+public enum Granite.NotificationButtonPurpose {
+    /**
+     * Accept the incoming call
+     */
+    CALL_ACCEPT,
+
+    /**
+     * Decline the incoming call
+     */
+    CALL_DECLINE,
+
+    /**
+     * Hang up the ongoing call
+     */
+    CALL_HANG_UP;
+
+    public string to_string () {
+        switch (this) {
+            case CALL_ACCEPT:
+                return "call.accept";
+            case CALL_DECLINE:
+                return "call.accept";
+            case CALL_HANG_UP:
+                return "call.accept";
+            default:
+                return "";
+        }
+    }
+}
+
+[Flags]
+[Version (since = "9.0.0")]
+public enum Granite.NotificationDisplayFlags {
+    /**
+     * The notification is displayed only as a bubble and won’t be kept in the Notifications menu.
+     *
+     * It’s a programmer error to specify tray at the same time.
+     */
+    TRANSIENT,
+
+    /**
+     * No bubble for the notification will be displayed and the notification is placed directly in the Notifications menu
+     *
+     * It’s a programmer error to specify transient at the same time
+     */
+    SILENT,
+
+    /**
+     * Make the notification persistent in the Notifications menu. It cannot be dismissed with a gesture or close button.
+     *
+     * Will be automatically cleared when the app is no longer running
+     */
+    ACTIVITY,
+
+    /**
+     * Don’t show the notification on the lock screen.
+     */
+    HIDE_ON_LOCK_SCREEN,
+
+    /**
+     * All content of the notification will be hidden on the lock screen.
+     */
+    HIDE_CONTENT_ON_LOCK_SCREEN,
+
+    /**
+     * If a notification with the same id exists already, close the old notification bubble and send a new bubble.
+     *
+     * If this hint isn’t specified the notification bubble’s content is replaced with an animation
+     */
+    SHOW_AS_NEW;
+
+    public string[] to_array () {
+        string[] array = { };
+        if (TRANSIENT in this) {
+            array += "transient";
+        }
+
+        if (SILENT in this) {
+            array += "tray";
+        }
+
+        if (ACTIVITY in this) {
+            array += "persistent";
+        }
+
+        if (HIDE_ON_LOCK_SCREEN in this) {
+            array += "hide-on-lock-screen";
+        }
+
+        if (HIDE_CONTENT_ON_LOCK_SCREEN in this) {
+            array += "hide-content-on-lock-screen";
+        }
+
+        if (SHOW_AS_NEW in this) {
+            array += "show-as-new";
+        }
+
+        return array;
+    }
+}

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -6,6 +6,7 @@ libgranite_sources = files(
     'DateTime.vala',
     'Constants.vala',
     'Init.vala',
+    'Notification.vala',
     'StyleManager.vala',
 
     'Services/Application.vala',


### PR DESCRIPTION
[Glib.Notification](https://valadoc.org/gio-2.0/GLib.Notification.html) is kind of outdated and doesn't support what's in the new portal spec like button purpose or sounds, but  [Xdp.Portal.add_notification](https://valadoc.org/libportal/Xdp.Portal.add_notification.html) is super open ended and not nice to use. I think we need to provide our own notification class, so I'm making enums and flags with functions that can be used with Xdg.Portal instead of just constants. This will be clunky to use right now but will be much easier to use with a future Granite.Notification

Unless otherwise specified, I'm going off the [XDG Portal spec](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Notification.html) here

Categories
---
There are two specs (wow suprise). One is from [XDG Portal](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Notification.html), but there's also an [Fd.o Spec](https://specifications.freedesktop.org/notification/latest/categories.html).

A lot of the ones mentioned in the portal are not app-facing but OS-facing so I'm inclined not to include them. We can touch the portal directly (or use GLib.Notification) in host applications to provider these notification categories if necessary.

The fd.o spec includes "presence" notifications which may have been a thing in the time of AIM, but seems really outdated. It also includes things like "network" which seems like the domain of the host.

Priority
---

The [fd.o spec](https://specifications.freedesktop.org/notification/latest/urgency-levels.html) includes 3 levels, whereas the portal and [GLib ](https://valadoc.org/gio-2.0/GLib.NotificationPriority.html) include 4 priority levels. I'm inclined to go with portal and GLib here

I'd like to name these in a way that can help give guidance for their usage. "High" vs "Urgent" is too difficult to make good decisions about.

I'd like to also codify some expectations about notification expiration here to help clean up old notifications etc.

Display Flags
---

This includes some ways to specific where your notification should show up. Some of the names they use I don't like for our purposes so trying to give those better names

Button Purpose
---

So we can do nice things like colored circular icon buttons for calls etc

The portal spec also includes:
* "im.reply-with-text" which we currently don't support and seems difficult to support, so I didn't include it for now
* "call.enable-speakerphone" and disable, which I guess we're not mobile yet, so  I didn't include it for now