### PR TITLE
Styles: support levelbar

### DIFF
--- a/demo/Views/ControlsView.vala
+++ b/demo/Views/ControlsView.vala
@@ -169,10 +169,9 @@ public class ControlsView : DemoPage {
         var hdiscrete_levelbar = new Gtk.LevelBar.for_interval (0, 4) {
             mode = DISCRETE
         };
-        hdiscrete_levelbar.add_offset_value ("low", 1);
-        hdiscrete_levelbar.add_offset_value ("middle", 2);
-        hdiscrete_levelbar.add_offset_value ("high", 3);
-        hdiscrete_levelbar.add_offset_value ("full", 4);
+        hdiscrete_levelbar.add_offset_value (Granite.CssClass.ERROR, 1);
+        hdiscrete_levelbar.add_offset_value (Granite.CssClass.WARNING, 3);
+        hdiscrete_levelbar.add_offset_value (Granite.CssClass.SUCCESS, 4);
         hscale.adjustment.bind_property ("value", hdiscrete_levelbar, "value", SYNC_CREATE,
             (binding, from_value, ref to_value) => {
             to_value.set_double ((double) from_value * 4);
@@ -212,10 +211,9 @@ public class ControlsView : DemoPage {
             mode = DISCRETE,
             orientation = VERTICAL
         };
-        vdiscrete_levelbar.add_offset_value ("low", 5);
-        vdiscrete_levelbar.add_offset_value ("middle", 10);
-        vdiscrete_levelbar.add_offset_value ("high", 23);
-        vdiscrete_levelbar.add_offset_value ("full", 25);
+        vdiscrete_levelbar.add_offset_value (Granite.CssClass.ERROR, 25);
+        vdiscrete_levelbar.add_offset_value (Granite.CssClass.WARNING, 23);
+        vdiscrete_levelbar.add_offset_value (Granite.CssClass.SUCCESS, 20);
         vscale.adjustment.bind_property ("value", vdiscrete_levelbar, "value", SYNC_CREATE,
             (binding, from_value, ref to_value) => {
             to_value.set_double ((double) from_value * 25);

--- a/demo/Views/ControlsView.vala
+++ b/demo/Views/ControlsView.vala
@@ -156,7 +156,7 @@ public class ControlsView : DemoPage {
             draw_value = true,
             hexpand = true
         };
-        hscale.adjustment.value = 0.5;
+        hscale.adjustment.value = 0.8;
 
         var hprogressbar = new Gtk.ProgressBar ();
         hscale.adjustment.bind_property ("value", hprogressbar, "fraction", SYNC_CREATE);
@@ -192,7 +192,7 @@ public class ControlsView : DemoPage {
             height_request = 128,
             has_origin = false
         };
-        vscale.adjustment.value = 0.5;
+        vscale.adjustment.value = 0.1;
 
         var vprogressbar = new Gtk.ProgressBar () {
             inverted = true,

--- a/demo/Views/ControlsView.vala
+++ b/demo/Views/ControlsView.vala
@@ -152,8 +152,6 @@ public class ControlsView : DemoPage {
         };
         popover_button.popover = switchbutton_popover;
 
-        var scale_header = new Granite.HeaderLabel ("Scale");
-
         var hscale = new Gtk.Scale.with_range (HORIZONTAL, 0, 1, 0.01) {
             draw_value = true,
             hexpand = true
@@ -163,9 +161,32 @@ public class ControlsView : DemoPage {
         var hprogressbar = new Gtk.ProgressBar ();
         hscale.adjustment.bind_property ("value", hprogressbar, "fraction", SYNC_CREATE);
 
-        var hcontrol_box = new Granite.Box (VERTICAL, DOUBLE);
+        var hcontinuous_levelbar = new Gtk.LevelBar () {
+            mode = CONTINUOUS
+        };
+        hscale.adjustment.bind_property ("value", hcontinuous_levelbar, "value", SYNC_CREATE);
+
+        var hdiscrete_levelbar = new Gtk.LevelBar.for_interval (0, 4) {
+            mode = DISCRETE
+        };
+        hdiscrete_levelbar.add_offset_value ("low", 1);
+        hdiscrete_levelbar.add_offset_value ("middle", 2);
+        hdiscrete_levelbar.add_offset_value ("high", 3);
+        hdiscrete_levelbar.add_offset_value ("full", 4);
+        hscale.adjustment.bind_property ("value", hdiscrete_levelbar, "value", SYNC_CREATE,
+            (binding, from_value, ref to_value) => {
+            to_value.set_double ((double) from_value * 4);
+            return true;
+        });
+
+        var hcontrol_box = new Granite.Box (VERTICAL, HALF);
+        hcontrol_box.append (new Granite.HeaderLabel ("Scale"));
         hcontrol_box.append (hscale);
+        hcontrol_box.append (new Granite.HeaderLabel ("ProgressBar"));
         hcontrol_box.append (hprogressbar);
+        hcontrol_box.append (new Granite.HeaderLabel ("LevelBar"));
+        hcontrol_box.append (hcontinuous_levelbar);
+        hcontrol_box.append (hdiscrete_levelbar);
 
         var vscale = new Gtk.Scale.with_range (VERTICAL, 0, 1, 0.01) {
             height_request = 128,
@@ -179,9 +200,33 @@ public class ControlsView : DemoPage {
         };
         vscale.adjustment.bind_property ("value", vprogressbar, "fraction", SYNC_CREATE);
 
+        var vcontinuous_levelbar = new Gtk.LevelBar () {
+            inverted = true,
+            mode = CONTINUOUS,
+            orientation = VERTICAL
+        };
+        vscale.adjustment.bind_property ("value", vcontinuous_levelbar, "value", SYNC_CREATE);
+
+        var vdiscrete_levelbar = new Gtk.LevelBar.for_interval (0, 25) {
+            inverted = true,
+            mode = DISCRETE,
+            orientation = VERTICAL
+        };
+        vdiscrete_levelbar.add_offset_value ("low", 5);
+        vdiscrete_levelbar.add_offset_value ("middle", 10);
+        vdiscrete_levelbar.add_offset_value ("high", 23);
+        vdiscrete_levelbar.add_offset_value ("full", 25);
+        vscale.adjustment.bind_property ("value", vdiscrete_levelbar, "value", SYNC_CREATE,
+            (binding, from_value, ref to_value) => {
+            to_value.set_double ((double) from_value * 25);
+            return true;
+        });
+
         var vcontrol_box = new Granite.Box (HORIZONTAL, DOUBLE);
         vcontrol_box.append (vscale);
         vcontrol_box.append (vprogressbar);
+        vcontrol_box.append (vcontinuous_levelbar);
+        vcontrol_box.append (vdiscrete_levelbar);
 
         var scale_box = new Granite.Box (HORIZONTAL, DOUBLE);
         scale_box.append (hcontrol_box);
@@ -201,7 +246,6 @@ public class ControlsView : DemoPage {
         box.append (mode_switch);
         box.append (switchbutton_header);
         box.append (popover_button);
-        box.append (scale_header);
         box.append (scale_box);
 
         child = box;

--- a/lib/Styles/Gtk/Index.scss
+++ b/lib/Styles/Gtk/Index.scss
@@ -7,6 +7,7 @@
 @import 'GridView.scss';
 @import 'HeaderBar.scss';
 @import 'Image.scss';
+@import 'LevelBar.scss';
 @import 'ListBox.scss';
 @import 'ListView.scss';
 @import 'MenuButton.scss';

--- a/lib/Styles/Gtk/LevelBar.scss
+++ b/lib/Styles/Gtk/LevelBar.scss
@@ -9,15 +9,18 @@ levelbar {
         &.filled {
             background-color: var(--accent-color);
 
+            &.error,
             &.low {
                 background-color: var(--error-color);
             }
 
+            &.warning,
             &.middle,
             &.high {
                 background-color: var(--warning-color);
             }
 
+            &.success,
             &.full {
                 background-color: var(--success-color);
             }

--- a/lib/Styles/Gtk/LevelBar.scss
+++ b/lib/Styles/Gtk/LevelBar.scss
@@ -1,0 +1,101 @@
+levelbar {
+    --trough-width: 2rem;
+    --trough-height: 1rem;
+
+    block {
+        @include trough;
+        transition: background-color duration("in-place") easing();
+
+        &.filled {
+            background-color: var(--accent-color);
+
+            &.low {
+                background-color: var(--error-color);
+            }
+
+            &.middle,
+            &.high {
+                background-color: var(--warning-color);
+            }
+
+            &.full {
+                background-color: var(--success-color);
+            }
+
+            &:backdrop {
+                background-color: color-mix(in srgb, var(--fg-color) 50%, transparent);
+            }
+        }
+    }
+
+    &.inverted {
+        block.filled {
+            &.low {
+                background-color: var(--success-color);
+            }
+
+            &.middle,
+            &.high {
+                background-color: var(--warning-color);
+            }
+
+            &.full {
+                background-color: var(--error-color);
+            }
+        }
+    }
+
+    &.horizontal block {
+        min-height: var(--trough-height);
+        min-width: var(--trough-width);
+    }
+
+    &.vertical block {
+        min-height: var(--trough-width);
+        min-width: var(--trough-height);
+    }
+}
+
+levelbar.discrete {
+    --trough-width: 0.25rem;
+
+    block {
+        border-radius: 0;
+    }
+
+    &.horizontal {
+        block {
+            margin-right: 1px;
+            min-width: var(--trough-width);
+        }
+
+        block:last-child {
+            border-top-right-radius: var(--trough-width);
+            border-bottom-right-radius: var(--trough-width);
+            margin-right: 0;
+        }
+
+        block:first-child {
+            border-top-left-radius: var(--trough-width);
+            border-bottom-left-radius: var(--trough-width);
+        }
+    }
+
+    &.vertical {
+        block {
+            margin-top: 1px;
+            min-height: var(--trough-width);
+        }
+
+        block:last-child {
+            border-bottom-right-radius: var(--trough-width);
+            border-bottom-left-radius: var(--trough-width);
+        }
+
+        block:first-child {
+            border-top-right-radius: var(--trough-width);
+            border-top-left-radius: var(--trough-width);
+            margin-top: 0;
+        }
+    }
+}

--- a/lib/Styles/Gtk/LevelBar.scss
+++ b/lib/Styles/Gtk/LevelBar.scss
@@ -25,8 +25,9 @@ levelbar {
                 background-color: var(--success-color);
             }
 
-            &:backdrop {
-                background-color: color-mix(in srgb, var(--fg-color) 50%, transparent);
+            &:backdrop,
+            &:disabled {
+                filter: grayscale(100%);
             }
         }
     }

--- a/lib/Styles/Gtk/LevelBar.scss
+++ b/lib/Styles/Gtk/LevelBar.scss
@@ -1,6 +1,6 @@
 levelbar {
     --trough-width: 2rem;
-    --trough-height: 1rem;
+    --trough-height: 0.5rem;
 
     block {
         @include trough;
@@ -82,6 +82,8 @@ levelbar.discrete {
     }
 
     &.vertical {
+        --trough-height: 0.75rem;
+
         block {
             margin-top: 1px;
             min-height: var(--trough-width);

--- a/lib/Styles/Gtk/LevelBar.scss
+++ b/lib/Styles/Gtk/LevelBar.scss
@@ -14,14 +14,14 @@ levelbar {
                 background-color: var(--error-color);
             }
 
-            &.warning,
+            &.high
             &.middle,
-            &.high {
-                background-color: var(--warning-color);
+            &.warning{
+                background-color: var(--warning-icon-color);
             }
 
-            &.success,
-            &.full {
+            &.full,
+            &.success {
                 background-color: var(--success-color);
             }
 
@@ -33,15 +33,18 @@ levelbar {
 
     &.inverted {
         block.filled {
-            &.low {
+            &.low,
+            &.success {
                 background-color: var(--success-color);
             }
 
+            &.high,
             &.middle,
-            &.high {
-                background-color: var(--warning-color);
+            &.warning {
+                background-color: var(--warning-icon-color);
             }
 
+            &.error,
             &.full {
                 background-color: var(--error-color);
             }


### PR DESCRIPTION
<img width="274" height="181" alt="Screenshot from 2026-09-10 11 27 18" src="https://github.com/user-attachments/assets/874b4334-3fac-49c1-af0d-90f5f917ee7c" />

My reasoning behind levelbar sizing is that currently we use it for things like disk fullness, battery charge, steps in a paged view etc.

For vertical discrete levelbars, the only use of this I've seen is for audio levels, so that's why I did this design

By default GTK assigns some of its own internal style classes, but I don't like having developers put an arbitrary string here, so I added support for named constants

I didn't include accent color here because your accent can be red or green or yellow